### PR TITLE
Fix restarted Plasma having incorrect CWD

### DIFF
--- a/install
+++ b/install
@@ -43,5 +43,5 @@ fi
 
 if $restartPlasmashell; then
 	killall plasmashell
-	kstart5 plasmashell
+	( cd $HOME && kstart5 plasmashell )
 fi


### PR DESCRIPTION
Calling kstart5 from the CWD/repo of this project leads to all newly opened programs will also run with CWD of the current project path. In particular, opening konsole opens the shell directly in the checkout of the repository.

Fix this by ensuring that we initiate the restart from $HOME.