### PR TITLE
Updated install script for nixos compat

### DIFF
--- a/install
+++ b/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Function to check if a command was successful
 check_command_success() {


### PR DESCRIPTION
NixOS doesn't have paths like other distros, by using `/usr/bin/env bash` this should work for nixos and have better compat for other distros as well.