### PR TITLE
fix: correct time datasource binding

### DIFF
--- a/package/contents/ui/TimeModel.qml
+++ b/package/contents/ui/TimeModel.qml
@@ -8,7 +8,7 @@ Item {
 	property string timezone: "Local"
 	property var currentTime: dataSource.data[timezone]["DateTime"]
 	property alias dataSource: dataSource
-	property var allTimezones: Qt.binding(function() {
+	property var allTimezones: {
 		var timezones = plasmoid.configuration.selectedTimeZones.toString()
 		if (timezones.length > 0) {
 			timezones = timezones.split(',')
@@ -19,7 +19,7 @@ Item {
 			timezones.push('Local')
 		}
 		return timezones
-	})
+	}
 
 	signal secondChanged()
 	signal minuteChanged()

--- a/package/contents/ui/TimeModel.qml
+++ b/package/contents/ui/TimeModel.qml
@@ -8,7 +8,7 @@ Item {
 	property string timezone: "Local"
 	property var currentTime: dataSource.data[timezone]["DateTime"]
 	property alias dataSource: dataSource
-	property var allTimezones: {
+	property var allTimezones: Qt.binding(function() {
 		var timezones = plasmoid.configuration.selectedTimeZones.toString()
 		if (timezones.length > 0) {
 			timezones = timezones.split(',')
@@ -19,7 +19,7 @@ Item {
 			timezones.push('Local')
 		}
 		return timezones
-	}
+	})
 
 	signal secondChanged()
 	signal minuteChanged()
@@ -32,7 +32,7 @@ Item {
 		connectedSources: timeModel.allTimezones
 		interval: 1000
 		intervalAlignment: Plasma5Support.Types.NoAlignment
-		function onNewData(sourceName, data) {
+		onNewData: function(sourceName, data) {
 			if (sourceName === 'Local') {
 				timeModel.tick()
 			}


### PR DESCRIPTION
Fix TimeModel DataSource binding for Qt6 parsing and ensure onNewData handler runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns QML handler syntax for the time data source to ensure time updates propagate.
> 
> - Changes `TimeModel.qml` to use `onNewData: function(sourceName, data) { ... }` instead of `function onNewData(...)` so `timeModel.tick()` triggers on `Local` updates
> - No other logic changes; intervals and connected sources remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a0ed66c6077b1a26d0b08157d8895f7bf0031b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the time model's public event handler declaration—behavior remains unchanged but the handler is now declared differently. Integrations that reference this handler should be checked for compatibility.

* **Documentation**
  * No user-facing behavior changes; no docs updates required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->