### PR TITLE
fix: correct time datasource binding

### DIFF
--- a/package/contents/ui/TimeModel.qml
+++ b/package/contents/ui/TimeModel.qml
@@ -8,7 +8,7 @@ Item {
 	property string timezone: "Local"
 	property var currentTime: dataSource.data[timezone]["DateTime"]
 	property alias dataSource: dataSource
-	property var allTimezones: Qt.binding(function() {
+	property var allTimezones: {
 		var timezones = plasmoid.configuration.selectedTimeZones.toString()
 		if (timezones.length > 0) {
 			timezones = timezones.split(',')
@@ -19,7 +19,7 @@ Item {
 			timezones.push('Local')
 		}
 		return timezones
-	})
+	}
 
 	signal secondChanged()
 	signal minuteChanged()

--- a/package/contents/ui/TimeModel.qml
+++ b/package/contents/ui/TimeModel.qml
@@ -8,7 +8,7 @@ Item {
 	property string timezone: "Local"
 	property var currentTime: dataSource.data[timezone]["DateTime"]
 	property alias dataSource: dataSource
-	property var allTimezones: {
+	property var allTimezones: Qt.binding(function() {
 		var timezones = plasmoid.configuration.selectedTimeZones.toString()
 		if (timezones.length > 0) {
 			timezones = timezones.split(',')
@@ -19,7 +19,7 @@ Item {
 			timezones.push('Local')
 		}
 		return timezones
-	}
+	})
 
 	signal secondChanged()
 	signal minuteChanged()
@@ -32,7 +32,7 @@ Item {
 		connectedSources: timeModel.allTimezones
 		interval: 1000
 		intervalAlignment: Plasma5Support.Types.NoAlignment
-		function onNewData(sourceName, data) {
+		onNewData: function(sourceName, data) {
 			if (sourceName === 'Local') {
 				timeModel.tick()
 			}


### PR DESCRIPTION
Fix TimeModel DataSource binding for Qt6 parsing and ensure onNewData handler runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes QML handler binding for time updates to work under Qt6.
> 
> - Changes `Plasma5Support.DataSource` handler from `function onNewData(...) {}` to `onNewData: function(...) {}` in `TimeModel.qml`, ensuring `timeModel.tick()` runs when `Local` time updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fc5aeb524359f35fca88e5f76a15a71df6c4ed4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->