### PR TITLE
security: harden OAuth redirect server and PKCE verifier

### DIFF
--- a/package/contents/scripts/google_redirect.py
+++ b/package/contents/scripts/google_redirect.py
@@ -20,7 +20,7 @@ logging.basicConfig(
     level=logging.DEBUG,
     format='%(asctime)s %(levelname)s: %(message)s'
 )
-logging.info("Script started with args: %s", sys.argv)
+logging.info("Script started")
 
 client_id = client_secret = listen_port = redirect_uri = code_verifier = None
 exit_code = 0

--- a/package/contents/scripts/google_redirect.py
+++ b/package/contents/scripts/google_redirect.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
     redirect_uri = args.redirect_uri or "http://127.0.0.1:{}/".format(listen_port)
     code_verifier = args.code_verifier
 
-    server_address = ("", listen_port)
+    server_address = ("127.0.0.1", listen_port)
     try:
         httpd = HTTPServer(server_address, OAuthRedirectHandler)
         logging.info("Server started on port %s", listen_port)

--- a/package/contents/ui/config/ConfigGoogleCalendar.qml
+++ b/package/contents/ui/config/ConfigGoogleCalendar.qml
@@ -168,9 +168,7 @@ ConfigPage {
 			cmd.push('--code_verifier')
 			cmd.push(authContext.pkceVerifier)
 		}
-		var cmdStr = JSON.stringify(cmd)
-		console.log('google_redirect.py command:', cmdStr)
-		// debugOutput.text = "Running:\n" + cmdStr + "\n\n"
+		// debugOutput.text = "Running:\n" + JSON.stringify(cmd) + "\n\n"
 		callbackListener.exec(cmd, function(cmd, exitCode, exitStatus, stdout, stderr) {
 			if (autoLoginCancelled) {
 				autoLoginInProgress = false

--- a/package/contents/ui/config/ConfigGoogleCalendar.qml
+++ b/package/contents/ui/config/ConfigGoogleCalendar.qml
@@ -35,6 +35,12 @@ ConfigPage {
 		return path.indexOf("file://") === 0 ? path.slice(7) : path
 	}
 
+	function redactCmd(cmd) {
+		return cmd.map(function(arg, i) {
+			return (i > 0 && cmd[i - 1] === '--client_secret') ? '***' : arg
+		})
+	}
+
 	function sortByKey(key, a, b){
 		if (typeof a[key] === "string") {
 			return a[key].toLowerCase().localeCompare(b[key].toLowerCase())
@@ -163,12 +169,11 @@ ConfigPage {
 			cmd.push('--client_secret')
 			cmd.push(authContext.clientSecret)
 		}
-		debugOutput.text = "Attempting to run:\n" + JSON.stringify(cmd) + "\n\n"
+		debugOutput.text = "Attempting to run:\n" + JSON.stringify(redactCmd(cmd)) + "\n\n"
 		if (authContext.pkceVerifier) {
 			cmd.push('--code_verifier')
 			cmd.push(authContext.pkceVerifier)
 		}
-		// debugOutput.text = "Running:\n" + JSON.stringify(cmd) + "\n\n"
 		callbackListener.exec(cmd, function(cmd, exitCode, exitStatus, stdout, stderr) {
 			if (autoLoginCancelled) {
 				autoLoginInProgress = false
@@ -822,7 +827,7 @@ ConfigPage {
 						cmd.push('--client_secret')
 						cmd.push(authContext.clientSecret)
 					}
-					debugOutput.text = "Manually starting listener...\nCommand: " + JSON.stringify(cmd) + "\n"
+					debugOutput.text = "Manually starting listener...\nCommand: " + JSON.stringify(redactCmd(cmd)) + "\n"
 					callbackListener.exec(cmd, function(cmd, exitCode, exitStatus, stdout, stderr) {
 						debugOutput.text += "Listener Finished.\nExit: " + exitCode + "\nStdout: " + stdout + "\nStderr: " + stderr + "\n"
 					})

--- a/package/contents/ui/lib/Pkce.js
+++ b/package/contents/ui/lib/Pkce.js
@@ -1,18 +1,13 @@
 .pragma library
 
-function generateVerifier(length) {
-    var size = length || 64
-    if (size < 43) {
-        size = 43
-    } else if (size > 128) {
-        size = 128
-    }
-    var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
-    var result = ""
-    for (var i = 0; i < size; i++) {
-        result += chars.charAt(Math.floor(Math.random() * chars.length))
-    }
-    return result
+// Qt.createUuid() uses a CSPRNG on supported platforms: /dev/urandom
+// on Linux, CryptGenRandom on Windows, arc4random on macOS.
+// Three UUIDv4s give 366 bits of entropy (3 x 122), exceeding
+// RFC 7636's recommended 256 bits. Result is 96 hex chars, within
+// the spec's 43-128 char range.
+function generateVerifier() {
+    return (Qt.createUuid() + Qt.createUuid() + Qt.createUuid())
+        .replace(/[{}\-]/g, '')
 }
 
 function base64UrlEncode(bytes) {


### PR DESCRIPTION
## Summary

Four independent security fixes, one commit each:

1. `google_redirect.py` was logging the full argv (including
   `--client_secret VALUE`) to `/tmp/google_redirect.log`, which is
   world-readable on most systems.

2. The OAuth redirect HTTP server bound to `0.0.0.0` (via `""`),
   making it reachable from other machines on the LAN during the
   login window. Changed to `127.0.0.1`. Both redirect modes
   (local and hosted GitHub Pages) POST from the user's own
   browser, so nothing relies on external binding.

3. `ConfigGoogleCalendar.qml` logged the full subprocess command
   (including `--client_secret`) to plasmashell's stdout, which
   ends up in journald. CONTRIBUTING.md already warns reporters
   not to paste this output — removing the log line eliminates
   the foot-gun.

4. `Pkce.js` generated the PKCE code verifier with `Math.random()`,
   which is not a CSPRNG. Replaced with `Qt.createUuid()` (three
   concatenated, 366 bits of entropy) which uses `/dev/urandom` on
   Linux, `CryptGenRandom` on Windows, and `arc4random` on macOS.
   RFC 7636 §7.1 requires cryptographically random verifiers.

A follow-up issue for the missing OAuth `state` parameter will be
filed separately — that one needs design discussion rather than
a trivial fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced network security by restricting server to local connections only.
  * Improved authentication security through stronger random number generation.
  * Reduced exposure of sensitive information in system logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->