### PR TITLE
fix: don't mark config dirty on no-op writes

### DIFF
--- a/package/contents/ui/lib/ConfigPage.qml
+++ b/package/contents/ui/lib/ConfigPage.qml
@@ -329,11 +329,25 @@ KCM.SimpleKCM {
 			return fallback
 		}
 
+		function isEqual(a, b) {
+			if (a === b) return true
+			if (typeof a === 'object' && typeof b === 'object') {
+				return JSON.stringify(a) === JSON.stringify(b)
+			}
+			return false
+		}
+
 		function write(key, value) {
 			var prop = "cfg_" + key
 			if (prop in page) {
+				if (isEqual(page[prop], value)) {
+					return
+				}
 				page[prop] = value
 			} else if (typeof plasmoid !== "undefined" && plasmoid.configuration) {
+				if (isEqual(plasmoid.configuration[key], value)) {
+					return
+				}
 				plasmoid.configuration[key] = value
 			}
 			if (typeof kcm !== "undefined") {


### PR DESCRIPTION
## Summary

`configBridge.write()` in `ConfigPage.qml` unconditionally set `kcm.needsSave = true`, even when writing the same value already stored. Several components write config during initialization:

- `ConfigComboBox.onCompleted` (sets `currentIndex`, triggers `onCurrentIndexChanged` → write)
- `ConfigCalendar.onCompleted` (same pattern)
- `GoogleLoginManager.migrateDefaultClientIfNeeded` (writes `latestClientId`/`latestClientSecret` on every load when conditions match, which is most users)
- `ConfigGoogleCalendar` writes `googleRedirectMode` to `"local"` on every page load

Result: switching between config tabs always prompts "you have unsaved changes" even when nothing was modified.

## Fix

Added an `isEqual()` helper and guard `write()` against no-op writes. Uses `===` for primitives, `JSON.stringify` for objects/arrays.

## Side effect

Some settings that intermittently didn't survive plasmashell restart now do — likely because the constant dirty-flag noise was interfering with save timing. Not claimed as a confirmed fix for that behaviour, just flagged for reference.

Tested on Plasma 6 / Debian Trixie.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced token generation with improved cryptographic methods.
  * Restricted local service to localhost binding only.

* **Improvements**
  * Added optimization to skip redundant configuration updates.
  * Simplified logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->