### PR TITLE
Fix ICS calendars never fetching; expand recurring events; harden ExecUtil

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,14 +10,14 @@ branch your change should target, open an issue first.
 1. Fork the repo.
 2. Clone the branch you want to work on:
 
-```
+```bash
 git clone -b master https://github.com/ALikesToCode/plasma-applet-eventcalendar.git
 cd plasma-applet-eventcalendar
 ```
 
 3. Install the widget locally:
 
-```
+```bash
 ./install
 ```
 
@@ -50,7 +50,7 @@ or full redirect URLs. Redact them before sharing.
 
 Run the automated checks that cover your change:
 
-```
+```bash
 node --test tests/*.test.js
 python3 -m unittest discover -s tests -p '*_test.py' -v
 find package/contents/ui -name '*.qml' -exec qmllint {} +

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for helping keep Event Calendar alive.
 
-The Plasma 6 work lives on the `plasma-6` branch. If you are not sure which
+The Plasma 6 work lives on the `master` branch. If you are not sure which
 branch your change should target, open an issue first.
 
 ## Quick start
@@ -11,7 +11,7 @@ branch your change should target, open an issue first.
 2. Clone the branch you want to work on:
 
 ```
-git clone -b plasma-6 https://github.com/ALikesToCode/plasma-applet-eventcalendar.git
+git clone -b master https://github.com/ALikesToCode/plasma-applet-eventcalendar.git
 cd plasma-applet-eventcalendar
 ```
 
@@ -48,8 +48,16 @@ or full redirect URLs. Redact them before sharing.
 
 ## Testing
 
-There are no automated tests. Please include manual test steps in your PR.
-At minimum:
+Run the automated checks that cover your change:
+
+```
+node --test tests/*.test.js
+python3 -m unittest discover -s tests -p '*_test.py' -v
+find package/contents/ui -name '*.qml' -exec qmllint {} +
+shellcheck --severity=warning install update build package/translate/build package/translate/merge
+```
+
+Please also include manual test steps in your PR. At minimum:
 
 - Open the widget settings.
 - Toggle your change and verify it applies after clicking Apply/OK.
@@ -62,4 +70,3 @@ Include:
 - What changed and why.
 - Screenshots for UI changes.
 - Plasma version tested on.
-

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -2,9 +2,9 @@
 
 This project is community maintained.
 
-The `plasma-6` branch is the active branch for KDE Plasma 6.
+The `master` branch is active for KDE Plasma 6. The `plasma-5` branch is the
+legacy Plasma 5 line; `plasma-6` is reserved for development and testing.
 
 My personal time is limited, so I may not be able to address non critical
 issues quickly. If you can help, please open a pull request. Even small fixes
 and documentation updates are appreciated.
-

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,11 @@ Core runtime:
 - `libcanberra` (optional, for notification sounds)
 
 Feature-specific (optional):
-- ICalendar (.ics) import: `python3-icalendar` (Python `icalendar` module)
+- ICalendar (.ics) import:
+  - `icalendar>=6.1,<8`
+  - `recurring-ical-events>=3.8,<4` for RRULE, RDATE, EXDATE, and RECURRENCE-ID expansion
+  - The install/update scripts place these Python packages under
+    `~/.local/share/plasma_org.kde.plasma.eventcalendar/python` when they are not already available.
 - Local PIM/Akonadi calendars: `akonadi` + `kdepim-addons` (provides `PimCalendarsModel`)
 - Create local events: `konsolekalendar` (from kdepim runtime/tools)
 - Mouse wheel volume presets:
@@ -33,6 +37,7 @@ Install/update/uninstall scripts:
 - `kpackagetool6` (Plasma 6) or `kpackagetool5` (Plasma 5)
 - `qdbus` or `qdbus6` (reload/remove widgets)
 - `jq` (read metadata)
+- `python3-pip` / `python-pip` (install user-local iCalendar recurrence support)
 
 Note: package names vary by distro. The install script attempts to install `kpackagetool` and `jq` on Debian/Arch/Fedora; on other distros, install manually.
 

--- a/build
+++ b/build
@@ -43,12 +43,12 @@ check_command_success() {
 ## Initialize Color Variables and Functions
 initialize_colors() {
         # Color definitions
-        TC_Red='\033[31m'; TC_Orange='\033[33m';
-        TC_LightGray='\033[90m'; TC_LightRed='\033[91m'; TC_LightGreen='\033[92m'; TC_Yellow='\033[93m'; TC_LightBlue='\033[94m';
+        TC_Red='\033[31m';
+        TC_LightGray='\033[90m'; TC_LightGreen='\033[92m';
         TC_Reset='\033[0m'; TC_Bold='\033[1m';
         if [ ! -t 1 ]; then
-                TC_Red=''; TC_Orange='';
-                TC_LightGray=''; TC_LightRed=''; TC_LightGreen=''; TC_Yellow=''; TC_LightBlue='';
+                TC_Red='';
+                TC_LightGray=''; TC_LightGreen='';
                 TC_Bold=''; TC_Reset='';
         fi
 
@@ -75,8 +75,8 @@ check_qml_versions() {
 handle_translations() {
         if [ -d "package/translate" ]; then
                 echoGray "[build] translate dir found, running merge."
-                (cd package/translate && sh ./merge)
-                (cd package/translate && sh ./build)
+                (cd package/translate && bash ./merge)
+                (cd package/translate && bash ./build)
                 if type "git" > /dev/null; then
                         if [ "$(git diff --stat package/translate)" != "" ]; then
                                 echoRed "[build] Changed detected. Cancelling build."
@@ -110,9 +110,11 @@ package_plasmoid() {
                 exit 1
         fi
 
-        local packageNamespace=$(read_metadata "KPlugin.Id")
+        local packageNamespace
+        packageNamespace=$(read_metadata "KPlugin.Id")
         local packageName="${packageNamespace##*.}" # Strip namespace (Eg: "org.kde.plasma.")
-        local packageVersion=$(read_metadata "KPlugin.Version")
+        local packageVersion
+        packageVersion=$(read_metadata "KPlugin.Version")
 
         if [ -z "$packageNamespace" ] || [ -z "$packageVersion" ]; then
                 echoRed "[error] Failed to read KPlugin.Id or KPlugin.Version from metadata.json"
@@ -120,14 +122,14 @@ package_plasmoid() {
         fi
 
         local filename="${packageName}-v${packageVersion}${filenameTag}.${packageExt}"
-        rm -f ${packageName}-v*.${packageExt} # Cleanup
+        rm -f -- "${packageName}"-v*."${packageExt}" # Cleanup
         echoGray "[${packageExt}] Zipping '${filename}'"
         (cd package \
-                && zip -r $filename * \
-                && mv $filename $startDir/$filename \
+                && zip -r "$filename" ./* \
+                && mv "$filename" "$startDir/$filename" \
         )
-        echoGray "[${packageExt}] md5: $(md5sum $filename | awk '{ print $1 }')"
-        echoGray "[${packageExt}] sha256: $(sha256sum $filename | awk '{ print $1 }')"
+        echoGray "[${packageExt}] md5: $(md5sum "$filename" | awk '{ print $1 }')"
+        echoGray "[${packageExt}] sha256: $(sha256sum "$filename" | awk '{ print $1 }')"
 }
 
 # Main Script Logic
@@ -139,4 +141,4 @@ package_plasmoid
 echoGreen "[build] Packaging completed successfully."
 
 # Return to start directory
-cd $startDir
+cd "$startDir" || exit 1

--- a/build
+++ b/build
@@ -45,11 +45,11 @@ initialize_colors() {
         # Color definitions
         TC_Red='\033[31m';
         TC_LightGray='\033[90m'; TC_LightGreen='\033[92m';
-        TC_Reset='\033[0m'; TC_Bold='\033[1m';
+        TC_Reset='\033[0m';
         if [ ! -t 1 ]; then
                 TC_Red='';
                 TC_LightGray=''; TC_LightGreen='';
-                TC_Bold=''; TC_Reset='';
+                TC_Reset='';
         fi
 
         # Color echo functions
@@ -102,14 +102,6 @@ convert_metadata() {
 
 ## Package the plasmoid
 package_plasmoid() {
-        if ! type "zip" > /dev/null; then
-                echoRed "[error] 'zip' command not found."
-                if type "zypper" > /dev/null; then
-                        echoRed "[error] Opensuse detected, please run: ${TC_Bold}sudo zypper install zip"
-                fi
-                exit 1
-        fi
-
         local packageNamespace
         packageNamespace=$(read_metadata "KPlugin.Id")
         local packageName="${packageNamespace##*.}" # Strip namespace (Eg: "org.kde.plasma.")
@@ -124,10 +116,18 @@ package_plasmoid() {
         local filename="${packageName}-v${packageVersion}${filenameTag}.${packageExt}"
         rm -f -- "${packageName}"-v*."${packageExt}" # Cleanup
         echoGray "[${packageExt}] Zipping '${filename}'"
-        (cd package \
-                && zip -r "$filename" ./* \
-                && mv "$filename" "$startDir/$filename" \
-        )
+        if type "zip" > /dev/null; then
+                (cd package \
+                        && zip -r "$filename" ./* \
+                        && mv "$filename" "$startDir/$filename" \
+                )
+        else
+                echoGray "[${packageExt}] 'zip' not found; using Python's zipfile module."
+                (cd package \
+                        && python3 -m zipfile -c "$filename" ./* \
+                        && mv "$filename" "$startDir/$filename" \
+                )
+        fi
         echoGray "[${packageExt}] md5: $(md5sum "$filename" | awk '{ print $1 }')"
         echoGray "[${packageExt}] sha256: $(sha256sum "$filename" | awk '{ print $1 }')"
 }

--- a/build
+++ b/build
@@ -75,16 +75,19 @@ check_qml_versions() {
 handle_translations() {
         if [ -d "package/translate" ]; then
                 echoGray "[build] translate dir found, running merge."
-                (cd package/translate && bash ./merge)
-                (cd package/translate && bash ./build)
-                if type "git" > /dev/null; then
-                        if [ "$(git diff --stat package/translate)" != "" ]; then
-                                echoRed "[build] Changed detected. Cancelling build."
-                                git diff --stat .
-                                exit 1
-                        fi
-                else
-                        echoGray "[build] Git not found, skipping translation diff check."
+                if ! (cd package/translate && bash ./merge); then
+                        echoRed "[build] Translation extraction failed."
+                        exit 1
+                fi
+                if ! (cd package/translate && bash ./build); then
+                        echoRed "[build] Translation compilation failed."
+                        exit 1
+                fi
+                if git rev-parse --is-inside-work-tree > /dev/null 2>&1 \
+                        && ! git diff --quiet -- package/translate; then
+                        echoRed "[build] Translation changes detected. Cancelling build."
+                        git diff --stat -- package/translate
+                        exit 1
                 fi
         fi
 }

--- a/build
+++ b/build
@@ -119,7 +119,7 @@ package_plasmoid() {
         local filename="${packageName}-v${packageVersion}${filenameTag}.${packageExt}"
         rm -f -- "${packageName}"-v*."${packageExt}" # Cleanup
         echoGray "[${packageExt}] Zipping '${filename}'"
-        if type "zip" > /dev/null; then
+        if command -v zip > /dev/null 2>&1; then
                 (cd package \
                         && zip -r "$filename" ./* \
                         && mv "$filename" "$startDir/$filename" \

--- a/docs/index.html
+++ b/docs/index.html
@@ -96,14 +96,14 @@
       <div class="card">
         <h3>Install via GitHub</h3>
         <p style="margin-bottom: 12px;">Run the following commands in your terminal:</p>
-        <pre class="code-block command-line" data-prompt="$"><code class="language-bash">git clone -b plasma-6 https://github.com/ALikesToCode/plasma-applet-eventcalendar.git eventcalendar
+        <pre class="code-block command-line" data-prompt="$"><code class="language-bash">git clone -b master https://github.com/ALikesToCode/plasma-applet-eventcalendar.git eventcalendar
 cd eventcalendar
-sh ./install</code></pre>
+./install</code></pre>
 
         <h3>Updating</h3>
         <p style="margin-bottom: 12px;">To update to the latest version:</p>
         <pre class="code-block command-line" data-prompt="$"><code class="language-bash">cd eventcalendar
-sh ./update</code></pre>
+./update</code></pre>
         <p class="status">Note: The install script will restart Plasmashell so you don't have to relog.</p>
       </div>
     </section>

--- a/install
+++ b/install
@@ -148,6 +148,7 @@ DISTRO_FAMILY=""
 PLASMA_MAJOR=""
 KPACKAGE_TOOL=""
 PACKAGES_UPDATED=false
+PYTHON_PACKAGE_DIR="$HOME/.local/share/plasma_org.kde.plasma.eventcalendar/python"
 
 detect_distro() {
     if [ -f /etc/os-release ]; then
@@ -213,6 +214,40 @@ install_packages_optional() {
     done
 }
 
+install_python_calendar_dependencies() {
+    local python_path="$PYTHON_PACKAGE_DIR"
+    local import_path="$python_path"
+    if [ -n "${PYTHONPATH:-}" ]; then
+        import_path="$python_path:$PYTHONPATH"
+    fi
+
+    if PYTHONPATH="$import_path" python3 -c 'import icalendar, recurring_ical_events' >/dev/null 2>&1; then
+        return 0
+    fi
+    if ! python3 -m pip --version >/dev/null 2>&1; then
+        log "WARNING: python3-pip is unavailable; recurring iCalendar events will not be expanded."
+        return 0
+    fi
+    if ! mkdir -p "$python_path"; then
+        log "WARNING: Could not create the local Python dependency directory."
+        return 0
+    fi
+
+    log "Installing recurring iCalendar support in the applet data directory..."
+    if ! python3 -m pip install \
+        --disable-pip-version-check \
+        --no-warn-script-location \
+        --upgrade \
+        --target "$python_path" \
+        'recurring-ical-events>=3.8,<4'; then
+        log "WARNING: recurring-ical-events failed to install; recurring events may be missing."
+        return 0
+    fi
+    if ! PYTHONPATH="$import_path" python3 -c 'import icalendar, recurring_ical_events' >/dev/null 2>&1; then
+        log "WARNING: Installed iCalendar dependencies could not be imported."
+    fi
+}
+
 # Function to install required packages
 install_requirements() {
     detect_distro
@@ -242,6 +277,7 @@ install_requirements() {
             )
             optional_packages=(
                 "python3-icalendar"
+                "python3-pip"
                 "akonadi-server"
                 "kdepim-addons"
                 "konsolekalendar"
@@ -268,6 +304,7 @@ install_requirements() {
             )
             optional_packages=(
                 "python-icalendar"
+                "python-pip"
                 "akonadi"
                 "kdepim-addons"
                 "kdepim-runtime"
@@ -294,6 +331,7 @@ install_requirements() {
             )
             optional_packages=(
                 "python3-icalendar"
+                "python3-pip"
                 "akonadi-server"
                 "kdepim-addons"
                 "kdepim-runtime"
@@ -357,6 +395,7 @@ KPACKAGE_TOOL="$(select_kpackage_tool "$PLASMA_MAJOR")"
 
 # Install script requirements
 install_requirements
+install_python_calendar_dependencies
 
 if ! command -v "$KPACKAGE_TOOL" >/dev/null 2>&1; then
     for candidate in kpackagetool6 kpackagetool5 kpackagetool; do

--- a/install
+++ b/install
@@ -451,6 +451,10 @@ if [ -z "$packageNamespace" ] || [ "$packageNamespace" = "null" ]; then
     log "ERROR: Failed to read package information from metadata."
     exit 1
 fi
+if [[ ! "$packageNamespace" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    log "ERROR: Refusing unsafe package namespace: $packageNamespace"
+    exit 1
+fi
 
 # Check if package type is available
 if ! "$KPACKAGE_TOOL" --list-types | grep -q "Plasma/Applet"; then
@@ -461,14 +465,15 @@ fi
 # Install or update the package
 INSTALL_DIR="$HOME/.local/share/plasma/plasmoids"
 mkdir -p "$INSTALL_DIR"
+PACKAGE_INSTALL_DIR="${INSTALL_DIR:?}/${packageNamespace:?}"
 
-if [ -d "$INSTALL_DIR/$packageNamespace" ]; then
+if [ -d "$PACKAGE_INSTALL_DIR" ]; then
     log "Updating existing package..."
-    rm -rf "$INSTALL_DIR/$packageNamespace"
+    rm -rf -- "$PACKAGE_INSTALL_DIR"
 fi
 
 log "Installing package..."
-cp -r package "$INSTALL_DIR/$packageNamespace"
+cp -r package "$PACKAGE_INSTALL_DIR"
 
 QDBUS_BIN=$(command -v qdbus || command -v qdbus6) || {
     echo "qdbus not found" >&2

--- a/install
+++ b/install
@@ -451,7 +451,9 @@ if [ -z "$packageNamespace" ] || [ "$packageNamespace" = "null" ]; then
     log "ERROR: Failed to read package information from metadata."
     exit 1
 fi
-if [[ ! "$packageNamespace" =~ ^[A-Za-z0-9._-]+$ ]]; then
+if [[ ! "$packageNamespace" =~ ^[A-Za-z0-9._-]+$ \
+    || "$packageNamespace" == "." \
+    || "$packageNamespace" == ".." ]]; then
     log "ERROR: Refusing unsafe package namespace: $packageNamespace"
     exit 1
 fi

--- a/package/contents/scripts/icsjson.py
+++ b/package/contents/scripts/icsjson.py
@@ -36,10 +36,10 @@ def debug(*args):
 		print(*args)
 
 
-def date_to_json(date_obj):
-	if isinstance(date_obj.dt, datetime.datetime):
-		return {"dateTime": date_obj.dt.isoformat()}
-	return {"date": date_obj.dt.isoformat()}
+def date_to_json(date_value):
+	if isinstance(date_value, datetime.datetime):
+		return {"dateTime": date_value.isoformat()}
+	return {"date": date_value.isoformat()}
 
 
 def stringify(value):
@@ -50,14 +50,22 @@ def get_event_date(event, key):
 	value = event.get(key)
 	if value is None or not hasattr(value, "dt"):
 		return None
-	return value
+	return value.dt
 
 
 def get_event_bounds(event):
 	start = get_event_date(event, "DTSTART")
 	if start is None:
 		return None, None
-	end = get_event_date(event, "DTEND") or start
+	end = getattr(event, "end", None) or get_event_date(event, "DTEND")
+	if end is None:
+		duration = get_event_date(event, "DURATION")
+		if isinstance(duration, datetime.timedelta):
+			end = start + duration
+		elif isinstance(start, datetime.date) and not isinstance(start, datetime.datetime):
+			end = start + datetime.timedelta(days=1)
+		else:
+			end = start
 	return start, end
 
 
@@ -69,8 +77,8 @@ def build_event_uid(event, start_date, end_date):
 	summary = stringify(event.get("SUMMARY")).strip()
 	digest = hashlib.sha1(
 		"|".join([
-			start_date.dt.isoformat(),
-			end_date.dt.isoformat(),
+			start_date.isoformat(),
+			end_date.isoformat(),
 			summary,
 		]).encode("utf-8", "ignore")
 	).hexdigest()
@@ -83,9 +91,12 @@ def events_to_json(event_list=None, indent=4):
 
 	data = {"items": []}
 	for event in event_list:
+		status = stringify(event.get("STATUS")).strip().lower()
+		if status == "cancelled":
+			continue
 		start_date, end_date = get_event_bounds(event)
 		if start_date is None or end_date is None:
-			debug("Skipping event without DTSTART/DTEND", stringify(event.get("SUMMARY")))
+			debug("Skipping event without a usable DTSTART/end", stringify(event.get("SUMMARY")))
 			continue
 
 		ical_uid = build_event_uid(event, start_date, end_date)
@@ -95,10 +106,10 @@ def events_to_json(event_list=None, indent=4):
 			"iCalUID": ical_uid,
 			"id": "ics_{}_{}_{}".format(
 				ical_uid,
-				start_date.dt.isoformat(),
-				end_date.dt.isoformat(),
+				start_date.isoformat(),
+				end_date.isoformat(),
 			),
-			"status": "confirmed",
+			"status": status or "confirmed",
 			"htmlLink": "",
 			"summary": stringify(event.get("SUMMARY")),
 			"start": date_to_json(start_date),
@@ -111,6 +122,8 @@ def events_to_json(event_list=None, indent=4):
 			item["updated"] = event["LAST-MODIFIED"].dt.isoformat()
 		if "LOCATION" in event:
 			item["location"] = stringify(event.get("LOCATION"))
+		if "DESCRIPTION" in event:
+			item["description"] = stringify(event.get("DESCRIPTION"))
 
 		data["items"].append(item)
 
@@ -132,8 +145,8 @@ def event_within(event, start_time, end_time):
 	if event_start_date is None or event_end_date is None:
 		return False
 
-	event_start = ensure_date_time(event_start_date.dt)
-	event_end = ensure_date_time(event_end_date.dt)
+	event_start = ensure_date_time(event_start_date)
+	event_end = ensure_date_time(event_end_date)
 	start_time = ensure_date_time(start_time)
 	end_time = ensure_date_time(end_time)
 	if event_start == event_end:
@@ -238,12 +251,12 @@ class CalendarManager:
 		for event in self.events:
 			if event_within(event, start_time, end_time):
 				start_date, end_date = get_event_bounds(event)
-				debug("within", start_date.dt, end_date.dt)
+				debug("within", start_date, end_date)
 				yield event
 			else:
 				start_date, end_date = get_event_bounds(event)
 				if start_date and end_date:
-					debug("out", start_date.dt, end_date.dt)
+					debug("out", start_date, end_date)
 
 	def to_json(self):
 		return events_to_json(self.events)

--- a/package/contents/scripts/icsjson.py
+++ b/package/contents/scripts/icsjson.py
@@ -5,8 +5,16 @@ import ipaddress
 import json
 import os
 import socket
+import sys
 import urllib.parse
 import urllib.request
+
+LOCAL_DATA_DIR = os.path.realpath(
+	os.path.expanduser("~/.local/share/plasma_org.kde.plasma.eventcalendar")
+)
+LOCAL_PYTHON_DIR = os.path.join(LOCAL_DATA_DIR, "python")
+if os.path.isdir(LOCAL_PYTHON_DIR) and LOCAL_PYTHON_DIR not in sys.path:
+	sys.path.insert(0, LOCAL_PYTHON_DIR)
 
 from icalendar import Calendar
 
@@ -20,9 +28,7 @@ MAX_ICS_BYTES = 10 * 1024 * 1024
 REQUEST_TIMEOUT = 15
 ALLOWED_URL_SCHEMES = {"file", "http", "https"}
 SAFE_REMOTE_SCHEMES = {"http", "https"}
-LOCAL_ICS_DIR = os.path.realpath(
-	os.path.expanduser("~/.local/share/plasma_org.kde.plasma.eventcalendar")
-)
+LOCAL_ICS_DIR = LOCAL_DATA_DIR
 
 
 def debug(*args):
@@ -130,7 +136,9 @@ def event_within(event, start_time, end_time):
 	event_end = ensure_date_time(event_end_date.dt)
 	start_time = ensure_date_time(start_time)
 	end_time = ensure_date_time(end_time)
-	return event_start <= end_time and event_end >= start_time
+	if event_start == event_end:
+		return start_time <= event_start < end_time
+	return event_start < end_time and start_time < event_end
 
 
 def validate_remote_host(parsed_url):
@@ -260,7 +268,7 @@ if __name__ == "__main__":
 
 	query = subparsers.add_parser("query")
 	query.add_argument("startTime", type=argparse_date, help="Inclusive starting date in YYYY-MM-DD format")
-	query.add_argument("endTime", type=argparse_date, help="Inclusive ending date in YYYY-MM-DD format")
+	query.add_argument("endTime", type=argparse_date, help="Exclusive ending date in YYYY-MM-DD format")
 
 	subparsers.add_parser("add")
 	subparsers.add_parser("delete")

--- a/package/contents/scripts/icsjson.py
+++ b/package/contents/scripts/icsjson.py
@@ -10,6 +10,11 @@ import urllib.request
 
 from icalendar import Calendar
 
+try:
+	import recurring_ical_events  # expands RRULE/EXDATE/RECURRENCE-ID into occurrences
+except ImportError:
+	recurring_ical_events = None
+
 debugging = False
 MAX_ICS_BYTES = 10 * 1024 * 1024
 REQUEST_TIMEOUT = 15
@@ -108,7 +113,11 @@ def events_to_json(event_list=None, indent=4):
 
 def ensure_date_time(dt):
 	if isinstance(dt, datetime.date) and not isinstance(dt, datetime.datetime):
-		return datetime.datetime.combine(dt, datetime.time.min)
+		dt = datetime.datetime.combine(dt, datetime.time.min)
+	if isinstance(dt, datetime.datetime) and dt.tzinfo is not None:
+		# ICS feeds (eg. Outlook) mix tz-aware timed events with naive all-day
+		# dates; comparing them against the naive query bounds raises TypeError.
+		dt = dt.astimezone().replace(tzinfo=None)
 	return dt
 
 
@@ -212,6 +221,12 @@ class CalendarManager:
 		return self.cal.walk("vevent")
 
 	def query(self, start_time, end_time):
+		if recurring_ical_events is not None:
+			# Expand recurring series into individual occurrences (RRULE, EXDATE,
+			# RECURRENCE-ID overrides). Without this, recurring meetings only
+			# match on their series start date and every other occurrence is lost.
+			yield from recurring_ical_events.of(self.cal).between(start_time, end_time)
+			return
 		for event in self.events:
 			if event_within(event, start_time, end_time):
 				start_date, end_date = get_event_bounds(event)

--- a/package/contents/ui/EventModel.qml
+++ b/package/contents/ui/EventModel.qml
@@ -12,6 +12,7 @@ CalendarManager {
 
 	Component.onCompleted: {
 		bindSignals(plasmaCalendarManager)
+		bindSignals(icalManager)
 	}
 
 	//---

--- a/package/contents/ui/calendars/ICalManager.qml
+++ b/package/contents/ui/calendars/ICalManager.qml
@@ -1,5 +1,6 @@
 import QtQuick
 
+import "../ErrorType.js" as ErrorType
 import "../lib"
 
 CalendarManager {
@@ -7,6 +8,11 @@ CalendarManager {
 
 	calendarManagerId: "ical"
 	ExecUtil { id: executable }
+	Logger {
+		id: logger
+		name: "eventcalendar-ical"
+		showDebug: plasmoid.configuration.debugging
+	}
 
 	// property var eventsData: { "items": [] }
 
@@ -21,15 +27,24 @@ CalendarManager {
 	function getCalendar(calendarId) {
 		for (var i = 0; i < calendarList.length; i++) {
 			var calendarData = calendarList[i]
-			if (calendarData.url == calendarId) {
+			if (calendarData && calendarData.url == calendarId) {
 				return calendarData
 			}
 		}
 		return null
 	}
 
+	function calendarLabel(calendarData) {
+		return String(calendarData && calendarData.name || i18n("iCalendar"))
+	}
+
+	function safeProcessError(stderr) {
+		var message = String(stderr || i18n("Unknown iCalendar helper error")).trim()
+		return message.replace(/https?:\/\/\S+/gi, "[redacted URL]")
+	}
+
 	function fetchEvents(calendarData, startTime, endTime, callback) {
-		logger.debug('ical.fetchEvents', calendarData.url)
+		logger.debug('ical.fetchEvents', calendarLabel(calendarData))
 		var startDate = startTime.getFullYear() + '-' + (startTime.getMonth() + 1) + '-' + startTime.getDate()
 		var endDate = endTime.getFullYear() + '-' + (endTime.getMonth() + 1) + '-' + endTime.getDate()
 		var cmd = [
@@ -43,37 +58,59 @@ CalendarManager {
 		]
 		executable.execArgv(cmd, function(cmd, exitCode, exitStatus, stdout, stderr) {
 			if (exitCode) {
-				logger.log('ical.stderr', stderr)
-				return callback(stderr)
+				logger.log('ical.fetchError', calendarLabel(calendarData), exitCode, exitStatus)
+				return callback(safeProcessError(stderr || stdout))
 			}
+			var parsed
 			try {
-				callback(null, JSON.parse(stdout))
+				parsed = JSON.parse(stdout)
+				if (!(parsed && Array.isArray(parsed.items))) {
+					throw new Error("iCalendar helper returned an invalid event list")
+				}
 			} catch (err) {
-				logger.log('ical.parseError', err, stdout)
-				callback(err.toString())
+				logger.log('ical.parseError', calendarLabel(calendarData), err)
+				return callback(err.toString())
 			}
+			callback(null, parsed)
 		})
 	}
 
 	function fetchCalendar(calendarData) {
-		icalManager.asyncRequests += 0
+		icalManager.asyncRequests += 1
 		fetchEvents(calendarData, dateMin, dateMax, function(err, data) {
-			parseEventList(calendarData, data.items)
-			setCalendarData(calendarData.url, data)
-			icalManager.asyncRequestsDone += 1
+			try {
+				if (err) {
+					icalManager.error(
+						i18n("Could not load %1: %2", calendarLabel(calendarData), err),
+						ErrorType.UnknownError
+					)
+					return
+				}
+				var currentCalendar = getCalendar(calendarData.url)
+				if (!currentCalendar || currentCalendar.show === false) {
+					return
+				}
+				setCalendarData(calendarData.url, data)
+			} finally {
+				icalManager.asyncRequestsDone += 1
+			}
 		})
 	}
 
 	onFetchAllCalendars: {
 		for (var i = 0; i < calendarList.length; i++) {
 			var calendarData = calendarList[i]
-			fetchCalendar(calendarData)
+			if (calendarData && calendarData.show !== false && String(calendarData.url || "").trim()) {
+				fetchCalendar(calendarData)
+			}
 		}
 	}
 
 	onCalendarParsing: function(calendarId, data) {
 		var calendar = getCalendar(calendarId)
-		parseEventList(calendar, data.items)
+		if (calendar) {
+			parseEventList(calendar, data.items)
+		}
 	}
 
 	function parseEvent(calendar, event) {
@@ -82,6 +119,9 @@ CalendarManager {
 	}
 
 	function parseEventList(calendar, eventList) {
+		if (!calendar || !Array.isArray(eventList)) {
+			return
+		}
 		eventList.forEach(function(event) {
 			parseEvent(calendar, event)
 		})

--- a/package/contents/ui/lib/ExecUtil.qml
+++ b/package/contents/ui/lib/ExecUtil.qml
@@ -121,13 +121,18 @@ Plasma5Support.DataSource {
 	function runCommand(cmd, callback) {
 		if (typeof callback === 'function') {
 			if (listeners[cmd]) { // Our implementation only allows 1 callback per command.
-				exited.disconnect(listeners[cmd])
+				// Stale listener from a run that never called back (e.g. the
+				// process hung or died across suspend/resume). It was stored in
+				// the map but never connected to the `exited` signal, so calling
+				// exited.disconnect() on it throws and aborts runCommand —
+				// silently breaking every subsequent run of the same cmd.
 				delete listeners[cmd]
 			}
 			var listener = execCallback.bind(executable, callback)
 			listeners[cmd] = listener
 		}
 		// console.log('cmd', cmd)
+		disconnectSource(cmd) // clear any stuck source so an identical cmd re-executes
 		connectSource(cmd)
 	}
 

--- a/package/contents/ui/lib/ExecUtil.qml
+++ b/package/contents/ui/lib/ExecUtil.qml
@@ -16,11 +16,12 @@ Plasma5Support.DataSource {
 		var stdout = data["stdout"]
 		var stderr = data["stderr"]
 		var listener = listeners[cmd]
+		delete listeners[cmd]
+		disconnectSource(sourceName) // clean up the completed run before callbacks can restart it
 		if (listener) {
 			listener(cmd, exitCode, exitStatus, stdout, stderr)
 		}
 		exited(cmd, exitCode, exitStatus, stdout, stderr)
-		disconnectSource(sourceName) // cmd finished
 	}
 
 	signal exited(string cmd, int exitCode, int exitStatus, string stdout, string stderr)
@@ -119,20 +120,15 @@ Plasma5Support.DataSource {
 	}
 
 	function runCommand(cmd, callback) {
+		// A command may be restarted after a suspended process never completed.
+		// Remove both its stale callback and source before registering the new run.
+		delete listeners[cmd]
+		disconnectSource(cmd)
 		if (typeof callback === 'function') {
-			if (listeners[cmd]) { // Our implementation only allows 1 callback per command.
-				// Stale listener from a run that never called back (e.g. the
-				// process hung or died across suspend/resume). It was stored in
-				// the map but never connected to the `exited` signal, so calling
-				// exited.disconnect() on it throws and aborts runCommand —
-				// silently breaking every subsequent run of the same cmd.
-				delete listeners[cmd]
-			}
 			var listener = execCallback.bind(executable, callback)
 			listeners[cmd] = listener
 		}
 		// console.log('cmd', cmd)
-		disconnectSource(cmd) // clear any stuck source so an identical cmd re-executes
 		connectSource(cmd)
 	}
 
@@ -157,7 +153,6 @@ Plasma5Support.DataSource {
 	}
 
 	function execCallback(callback, cmd, exitCode, exitStatus, stdout, stderr) {
-		delete listeners[cmd]
 		callback(cmd, exitCode, exitStatus, stdout, stderr)
 	}
 

--- a/package/translate/ReadMe.md
+++ b/package/translate/ReadMe.md
@@ -8,7 +8,7 @@ Go to `~/.local/share/plasma/plasmoids/org.kde.plasma.eventcalendar/translate/` 
 
 ## New Translations
 
-1. Fill out [`template.pot`](template.pot) with your translations then open a [new issue](https://github.com/Zren/plasma-applet-eventcalendar/issues/new), name the file `spanish.txt`, attach the txt file to the issue (drag and drop).
+1. Fill out [`template.pot`](template.pot) with your translations then open a [new issue](https://github.com/ALikesToCode/plasma-applet-eventcalendar/issues/new), name the file `spanish.txt`, attach the txt file to the issue (drag and drop).
 
 Or if you know how to make a pull request
 
@@ -35,24 +35,24 @@ Or if you know how to make a pull request
 ## Status
 |  Locale  |  Lines  | % Done|
 |----------|---------|-------|
-| Template |     219 |       |
-| da       | 184/219 |   84% |
-| de       | 215/219 |   98% |
-| el       | 167/219 |   76% |
-| es       | 218/219 |   99% |
-| fi       | 215/219 |   98% |
-| fr       | 186/219 |   84% |
-| he       | 216/219 |   98% |
-| it       | 215/219 |   98% |
-| ja       | 183/219 |   83% |
-| ko       | 215/219 |   98% |
-| nl       | 219/219 |  100% |
-| pl       | 157/219 |   71% |
-| pt_BR    | 215/219 |   98% |
-| pt_PT    | 214/219 |   97% |
-| ru       | 215/219 |   98% |
-| sl       | 193/219 |   88% |
-| sv       | 179/219 |   81% |
-| tr       | 183/219 |   83% |
-| uk       | 157/219 |   71% |
-| zh_CN    | 166/219 |   75% |
+| Template |     299 |       |
+| da       | 170/299 |   56% |
+| de       | 200/299 |   66% |
+| el       | 156/299 |   52% |
+| es       | 203/299 |   67% |
+| fi       | 200/299 |   66% |
+| fr       | 172/299 |   57% |
+| he       | 201/299 |   67% |
+| it       | 200/299 |   66% |
+| ja       | 169/299 |   56% |
+| ko       | 201/299 |   67% |
+| nl       | 204/299 |   68% |
+| pl       | 148/299 |   49% |
+| pt_BR    | 200/299 |   66% |
+| pt_PT    | 199/299 |   66% |
+| ru       | 200/299 |   66% |
+| sl       | 178/299 |   59% |
+| sv       | 164/299 |   54% |
+| tr       | 169/299 |   56% |
+| uk       | 146/299 |   48% |
+| zh_CN    | 152/299 |   50% |

--- a/package/translate/build
+++ b/package/translate/build
@@ -2,13 +2,14 @@
 if [ -z "${BASH_VERSION:-}" ]; then
 	exec /usr/bin/env bash "$0" "$@"
 fi
+set -euo pipefail
 # Version: 7
 
 # This script will convert the *.po files to *.mo files, rebuilding the package/contents/locale folder.
 # Feature discussion: https://phabricator.kde.org/D5209
 # Eg: contents/locale/fr_CA/LC_MESSAGES/plasma_applet_org.kde.plasma.eventcalendar.mo
 
-DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd`
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 metadataFile="$DIR/../metadata.json"
 read_metadata() {
 	python3 - "$metadataFile" "$1" <<'PY'
@@ -69,27 +70,27 @@ fi
 echoGray "[translate/build] Compiling messages"
 
 function relativePath() {
-	basePath=`realpath -- "$1"`
-	longerPath=`realpath -- "$2"`
+	basePath=$(realpath -- "$1")
+	longerPath=$(realpath -- "$2")
 	echo "${longerPath#${basePath}*}"
 }
-catalogs=`find . -name '*.po' | sort`
+catalogs=$(find . -name '*.po' | sort)
 for cat in $catalogs; do
-	catLocale=`basename ${cat%.*}`
+	catLocale=$(basename "${cat%.*}")
 	moFilename="${catLocale}.mo"
 	installPath="${packageRoot}/contents/locale/${catLocale}/LC_MESSAGES/${projectName}.mo"
-	installPath=`realpath -- "$installPath"`
-	relativeInstallPath=`relativePath "${packageRoot}" "${installPath}"`
+	mkdir -p "$(dirname "$installPath")"
+	installPath=$(realpath -- "$installPath")
+	relativeInstallPath=$(relativePath "${packageRoot}" "${installPath}")
 	relativeInstallPath="${relativeInstallPath#/*}"
 	echoGray "[translate/build] Converting '${cat}' => '${relativeInstallPath}'"
 	msgfmt -o "${moFilename}" "${cat}"
-	mkdir -p "$(dirname "$installPath")"
 	mv "${moFilename}" "${installPath}"
 done
 
 echoGreen "[translate/build] Done building messages"
 
-if [ "$1" = "--restartplasma" ]; then
+if [ "${1:-}" = "--restartplasma" ]; then
 	echo "[translate/build] ${TC_Bold}Restarting plasmashell${TC_Reset}"
 	killall plasmashell
 	kstart5 plasmashell

--- a/package/translate/build
+++ b/package/translate/build
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+	exec /usr/bin/env bash "$0" "$@"
+fi
 # Version: 7
 
 # This script will convert the *.po files to *.mo files, rebuilding the package/contents/locale folder.
@@ -26,20 +29,18 @@ PY
 }
 
 plasmoidName=$(read_metadata "KPlugin.Id")
-website=$(read_metadata "KPlugin.Website")
-bugAddress="$website"
 packageRoot="${DIR}/.." # Root of translatable sources
 projectName="plasma_applet_${plasmoidName}" # project name
 
 ### Colors
 # https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux
 # https://stackoverflow.com/questions/911168/how-can-i-detect-if-my-shell-script-is-running-through-a-pipe
-TC_Red='\033[31m'; TC_Orange='\033[33m';
-TC_LightGray='\033[90m'; TC_LightRed='\033[91m'; TC_LightGreen='\033[92m'; TC_Yellow='\033[93m'; TC_LightBlue='\033[94m';
+TC_Red='\033[31m';
+TC_LightGray='\033[90m'; TC_LightGreen='\033[92m';
 TC_Reset='\033[0m'; TC_Bold='\033[1m';
 if [ ! -t 1 ]; then
-	TC_Red=''; TC_Orange='';
-	TC_LightGray=''; TC_LightRed=''; TC_LightGreen=''; TC_Yellow=''; TC_LightBlue='';
+	TC_Red='';
+	TC_LightGray=''; TC_LightGreen='';
 	TC_Bold=''; TC_Reset='';
 fi
 function echoTC() {

--- a/package/translate/da.po
+++ b/package/translate/da.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2019-05-04 00:48-0400\n"
 "Last-Translator: Chris Darnell <chris@cedeel.com>\n"
 "Language-Team: Chris Darnell <chris@cedeel.com>\n"
@@ -17,16 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 18.12.2\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Begivenhedskalender"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -49,6 +40,7 @@ msgid "Agenda"
 msgstr "Agenda"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Begivenheder"
 
@@ -68,10 +60,17 @@ msgstr "Vejr"
 msgid "Advanced"
 msgstr "Avanceret"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Hele dagen"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -94,6 +93,18 @@ msgid "Edit in browser"
 msgstr "Rediger i webbrowser"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "d. MMM"
@@ -103,40 +114,300 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "d. MMM"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Begivenhedskalender"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Ingen kalendere]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "til"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Hele dagen"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "Gem"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "Annuler"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "t"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "t.mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "t AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "t.mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1t"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr ""
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "d. MMMM yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Fx.: 9-17 Arbejde"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Vejrudsigten er ikke konfigureret.\n"
+"Gå til fanen 'Vejr' i indstillingerne, og indstil din by\n"
+"og/eller slå vejrgrafikken fra for at skjule dette område."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr ""
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Start"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Timer"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Timer udløbet"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 er udløbet"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Gentag"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Sæt timer på pause"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Start timer"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Lyd"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Indstil timer"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Begivenheder starter"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Begivenheder igang"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Kommende begivenheder"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Ikke navngivet)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Ingen kalendere]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr ""
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -186,8 +457,8 @@ msgid "Click Weather:"
 msgstr "Klik på vejret:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Åbn vejrudsigten i din webbrowser"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -195,12 +466,8 @@ msgid "Click Date:"
 msgstr "Klik på datoen:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Åbn ny begivenhed i din webbrowser"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Åbn ny begivenhed i en pop-op"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -219,8 +486,8 @@ msgid "Click Event:"
 msgstr "Klik på begivenhed:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Åbn begivenhed i din webbrowser"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -302,11 +569,6 @@ msgstr "Stil"
 msgid "Current Month Title:"
 msgstr ""
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "d. MMMM yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Vis kanter"
@@ -384,6 +646,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Plasma-kalenderplug-ins"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Blandet"
@@ -425,10 +693,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Vejrgrafik"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Timer"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -538,46 +802,230 @@ msgid "Enable Debugging"
 msgstr "Slå fejlrettelse til"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Log ind"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Synkroniseret."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Log ud"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Synkroniser med Google Kalender"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"Besøg <a href=\"%1\">%2</a> (åbner i din  webbrowser). Når du er logget ind "
-"og giver tilladelse til, at tilgå din kalender, får du en kode som skal "
-"skrives nedenfor."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Indtast koden her (fx.: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Indsend"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Ugyldig Google-autorisationskode"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -625,6 +1073,10 @@ msgid "Calendar Label"
 msgstr "Kalendermærke"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Gennemse"
 
@@ -641,12 +1093,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Pop-op-tip"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Kan ikke fravælge lokal tid fra pop-op-tippet"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -655,6 +1141,10 @@ msgstr "Data"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API App-ID:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -769,38 +1259,40 @@ msgstr "By-websted"
 msgid "Open Link"
 msgstr "Åbn link"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "til"
-
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "Gem"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "Annuler"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
 msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
@@ -824,154 +1316,67 @@ msgstr ""
 msgid "All files (%1)"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "t"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "t.mm"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "t AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "t.mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1t"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Vælg sprog…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Regionale indstillinger…"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Åbn vejrudsigten i din webbrowser"
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Åbn ny begivenhed i din webbrowser"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event Form"
+#~ msgstr "Åbn ny begivenhed i en pop-op"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM yyyy"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Åbn begivenhed i din webbrowser"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Fx.: 9-17 Arbejde"
+#~ msgid "Login"
+#~ msgstr "Log ind"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Vejrudsigten er ikke konfigureret.\n"
-"Gå til fanen 'Vejr' i indstillingerne, og indstil din by\n"
-"og/eller slå vejrgrafikken fra for at skjule dette område."
+#~ msgid "Currently Synched."
+#~ msgstr "Synkroniseret."
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr ""
+#~ msgid "Logout"
+#~ msgstr "Log ud"
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Start"
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "Besøg <a href=\"%1\">%2</a> (åbner i din  webbrowser). Når du er logget "
+#~ "ind og giver tilladelse til, at tilgå din kalender, får du en kode som "
+#~ "skal skrives nedenfor."
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Timer udløbet"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Indtast koden her (fx.: %1)"
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 er udløbet"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Ugyldig Google-autorisationskode"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Gentag"
+#~ msgid "Tooltip"
+#~ msgstr "Pop-op-tip"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Sæt timer på pause"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Kan ikke fravælge lokal tid fra pop-op-tippet"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Start timer"
+#~ msgid "Set Locale…"
+#~ msgstr "Regionale indstillinger…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Rul for at forøge varigheden"
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Lyd"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Indstil timer"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Begivenheder starter"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Begivenheder igang"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Kommende begivenheder"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Rul for at forøge varigheden"
 
 #~ msgid "Choose"
 #~ msgstr "Vælg"

--- a/package/translate/de.po
+++ b/package/translate/de.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2021-04-09 19:18+0200\n"
 "Last-Translator: Tim Lehner <tim.le20tl@gmail.com>\n"
 "Language-Team: German <>\n"
@@ -18,18 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.4.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Ereigniskalender"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
-"Miniprogramm für einen Kalender mit Ereignisansicht und Wetter, der "
-"Ereignisse mit Google Kalender synchronisiert."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -52,6 +41,7 @@ msgid "Agenda"
 msgstr "Ereignisse"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Ereignisse"
 
@@ -71,10 +61,17 @@ msgstr "Wettervorhersage"
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "ganztags"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -97,6 +94,18 @@ msgid "Edit in browser"
 msgstr "Im Webbrowser bearbeiten"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "d MMM"
@@ -106,43 +115,303 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "d MMM"
 
-#: ../contents/ui/calendars/CalendarManager.qml
-msgctxt "event with no summary"
-msgid "(No title)"
-msgstr "(Kein Titel)"
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Ereigniskalender"
 
 #: ../contents/ui/CalendarSelector.qml
 msgid "[No Calendars]"
 msgstr "[Keine Kalender]"
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "HTTP Fehler %1: %2"
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d MMM yyyy"
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "bis"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Ereignistitel"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "ganztags"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Ort hinzufügen"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Beschreibung hinzufügen"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&Sichern"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Abbrechen"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Enddatum hinzufügen"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "h AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1h"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Could not connect"
 msgstr "Verbindungsfehler"
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "HTTP Fehler %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Will try again soon."
 msgstr "Versuche in Kürze erneut."
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Limit der Wetter-API erreicht"
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid ""
 "Widget has been updated. Please logout and login to Google Calendar again."
 msgstr ""
 "Widget wurde aktualisiert. Bitte beim Google Kalender ab- und wieder "
 "anmelden."
 
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Von Googel abgemeldet. Bitte erneut anmelden."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "d. MMMM yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "z.B.: 9-17 Arbeit"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Wettervorhersage nicht konfiguriert.\n"
+"Ort in der Konfiguration zur Wettervorhersage einstellen,\n"
+"oder das Meteogramm ausschalten."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Fehler beim Abfragen der Wettervorhersage."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Start"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Timer"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Timer abgelaufen"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 vergangen"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Wiederholen"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Pausen-Timer"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Timer starten"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Ton"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Timer einstellen"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Startende Ereignisse"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Laufende Ereignisse"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Nächste Ereignisse"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr "Startet in %1"
+
+#: ../contents/ui/calendars/CalendarManager.qml
+msgctxt "event with no summary"
+msgid "(No title)"
+msgstr "(Kein Titel)"
+
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "Zu viele Anfragen. Versuche in Kürze erneut."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -191,8 +460,8 @@ msgid "Click Weather:"
 msgstr "Wettersymbol anklicken:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Vorhersage des Ortes im Webbrowser öffnen"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -200,12 +469,8 @@ msgid "Click Date:"
 msgstr "Klick auf Datum:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Neues Ereignis im Webbrowser öffnen"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Öffne neues Ereignis"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -224,8 +489,8 @@ msgid "Click Event:"
 msgstr "Klick auf Ereignis:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Öffne Ereignis im Webbrowser"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -305,11 +570,6 @@ msgstr "Stil"
 msgid "Current Month Title:"
 msgstr "Titel des aktuellen Monats:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "d. MMMM yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Ränder anzeigen"
@@ -387,6 +647,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Plasma Kalender Plugins"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Verschiedenes"
@@ -428,10 +694,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Meteogramm"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Timer"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -542,46 +804,230 @@ msgid "Enable Debugging"
 msgstr "Debugging aktivieren"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Anmelden"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Synchronisiert."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Abmelden"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Mit Google Kalender synchronisieren"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"Gehe auf <a href=\"%1\">%2</a> (öffnet sich im Webbrowser), melde dich an, "
-"und bestätige, dass dieses Miniprogramm auf deinen Kalender zugreifen darf. "
-"Füge anschließend den angezeigten Code in das folgende Textfeld ein."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Link kopieren"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Code hier eingeben (z.B. %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Absenden"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Ungültiger Authorisierungscode"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -629,6 +1075,10 @@ msgid "Calendar Label"
 msgstr "Kalenderbezeichnung"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Durchsuchen"
 
@@ -645,12 +1095,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Ereignisliste unter dem Kalender (eine Spalte)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Tooltip"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Lokale Zeit kann nicht aus dem Tooltip entfernt werden"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -659,6 +1143,10 @@ msgstr "Daten"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API App ID:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -773,39 +1261,41 @@ msgstr "Website des Ortes"
 msgid "Open Link"
 msgstr "Verknüpfung öffnen"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d MMM yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "bis"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Ereignistitel"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Ort hinzufügen"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Beschreibung hinzufügen"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&Sichern"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Abbrechen"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Enddatum hinzufügen"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -828,154 +1318,73 @@ msgstr "Klangdateien (%1)"
 msgid "All files (%1)"
 msgstr "Alle Dateien (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "h AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1h"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Limit der Wetter-API erreicht"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Von Googel abgemeldet. Bitte erneut anmelden."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Sprache einstellen"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Region einstellen…"
+#~ msgid ""
+#~ "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr ""
+#~ "Miniprogramm für einen Kalender mit Ereignisansicht und Wetter, der "
+#~ "Ereignisse mit Google Kalender synchronisiert."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Vorhersage des Ortes im Webbrowser öffnen"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Neues Ereignis im Webbrowser öffnen"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM yyyy"
+#~ msgid "Open New Event Form"
+#~ msgstr "Öffne neues Ereignis"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "z.B.: 9-17 Arbeit"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Öffne Ereignis im Webbrowser"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Wettervorhersage nicht konfiguriert.\n"
-"Ort in der Konfiguration zur Wettervorhersage einstellen,\n"
-"oder das Meteogramm ausschalten."
+#~ msgid "Login"
+#~ msgstr "Anmelden"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Fehler beim Abfragen der Wettervorhersage."
+#~ msgid "Currently Synched."
+#~ msgstr "Synchronisiert."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Start"
+#~ msgid "Logout"
+#~ msgstr "Abmelden"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Timer abgelaufen"
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "Gehe auf <a href=\"%1\">%2</a> (öffnet sich im Webbrowser), melde dich "
+#~ "an, und bestätige, dass dieses Miniprogramm auf deinen Kalender zugreifen "
+#~ "darf. Füge anschließend den angezeigten Code in das folgende Textfeld ein."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 vergangen"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Code hier eingeben (z.B. %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Wiederholen"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Ungültiger Authorisierungscode"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Pausen-Timer"
+#~ msgid "Tooltip"
+#~ msgstr "Tooltip"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Timer starten"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Lokale Zeit kann nicht aus dem Tooltip entfernt werden"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Blättern zum Einstellen der Dauer"
+#~ msgid "Set Locale…"
+#~ msgstr "Region einstellen…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Ton"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Timer einstellen"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Startende Ereignisse"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Laufende Ereignisse"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Nächste Ereignisse"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr "Startet in %1"
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Blättern zum Einstellen der Dauer"
 
 #~ msgid "Choose"
 #~ msgstr "Auswählen"

--- a/package/translate/de.po
+++ b/package/translate/de.po
@@ -261,7 +261,7 @@ msgstr ""
 
 #: ../contents/ui/Logic.qml
 msgid "Logged out of Google. Please login again."
-msgstr "Von Googel abgemeldet. Bitte erneut anmelden."
+msgstr "Von Google abgemeldet. Bitte erneut anmelden."
 
 #: ../contents/ui/MeteogramView.qml
 #, c-format

--- a/package/translate/el.po
+++ b/package/translate/el.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2018-06-07 01:37+0300\n"
 "Last-Translator: Chris P <skylin@protonmail.com>\n"
 "Language-Team: Chris P <skylin@protonmail.com>\n"
@@ -17,16 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.7\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Ημερολόγιο Συμβάντων"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -49,6 +40,7 @@ msgid "Agenda"
 msgstr "Ατζέντα"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Συμβάντα"
 
@@ -68,10 +60,17 @@ msgstr "Καιρός"
 msgid "Advanced"
 msgstr "Προχωρημένα"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Όλη την Ημέρα"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -94,6 +93,18 @@ msgid "Edit in browser"
 msgstr "Επεξεργασία στον φυλλομετρητή"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "d MMM"
@@ -103,9 +114,259 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Ημερολόγιο Συμβάντων"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Χωρίς Ημερολόγια]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "προς"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Όλη την Ημέρα"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "Αποθήκευση"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Ακύρωση"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1ώ"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1λ"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1δ"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr ""
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "d MMMM, yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM, yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Πχ: 9πμ-5μμ Εργασία"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Ο καιρός δεν έχει ρυθμιστεί.\n"
+"Πηγαίνετε στο Καιρός στις ρυθμίσεις του Event Calendar και ορίστε την πόλη "
+"σας,\n"
+"και / ή απενεργοποιήστε το μετεωρογράφημα για να αποκρύψετε αυτήν την "
+"περιοχή."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr ""
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Χρονομετρητής"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Ο χρονομετρητής τελείωσε"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 έχει παρέλθει"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Επανάληψη"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Παύση χρονομετρητή"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Εκκίνηση χρονομετρητή"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Ήχος"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr ""
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Εκκίνηση Συμβάντων"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Συμβάντα Σε Εξέλιξη"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Επόμενα Συμβάντα"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
 msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
@@ -113,30 +374,42 @@ msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Χωρίς Τίτλο)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Χωρίς Ημερολόγια]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr ""
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -186,8 +459,8 @@ msgid "Click Weather:"
 msgstr "Κλικ στον Καιρό:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Άνοιγμα Πρόγνωσης Καιρού στον Φυλλομετρητή"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -195,12 +468,8 @@ msgid "Click Date:"
 msgstr "Κλικ στην Ημέρα:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Άνοιγμα Νέου Συμβάντος στον Φυλλομετρητή"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Άνοιγμα Νέας Μορφής Συμβάντος"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -219,8 +488,8 @@ msgid "Click Event:"
 msgstr "Κλικ στο Συμβάν:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Άνοιξε το Συμβάν στον Φυλλομετρητή"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -301,11 +570,6 @@ msgstr "Στιλ"
 msgid "Current Month Title:"
 msgstr ""
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "d MMMM, yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Εμφάνιση Περιθωρίων"
@@ -383,6 +647,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Πρόσθετα Ημερολογίου Plasma"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Διάφορα"
@@ -424,10 +694,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Μετεωρογράφημα"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Χρονομετρητής"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -539,26 +805,176 @@ msgid "Enable Debugging"
 msgstr "Ενεργοποίηση Αποσφαλμάτωσης"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Σύνδεση"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Αυτή τη στιγμή είναι συγχρονισμένο."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Αποσύνδεση"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Για συγχρονισμό με το Ημερολόγιο Google"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -566,7 +982,44 @@ msgid "Copy Link"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -574,7 +1027,7 @@ msgid "Submit"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
+msgid "Update Selected"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -623,6 +1076,10 @@ msgid "Calendar Label"
 msgstr "Ετικέτα Ημερολογίου"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Πλοήγηση"
 
@@ -639,14 +1096,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Συμβουλή Εργαλείου"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
 msgstr ""
-"Δεν είναι δυνατή η κατάργηση της επιλογής Τοπική Ώρα από τη συμβουλή "
-"εργαλείου"
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -655,6 +1144,10 @@ msgstr "Δεδομένα"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "Αναγνωριστικό API Εφαρμογής:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -769,38 +1262,40 @@ msgstr "Ιστοσελίδα Πόλης"
 msgid "Open Link"
 msgstr "Άνοιγμα Συνδέσμου"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "προς"
-
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "Αποθήκευση"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Ακύρωση"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
 msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
@@ -824,156 +1319,54 @@ msgstr ""
 msgid "All files (%1)"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1ώ"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1λ"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1δ"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr ""
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Ορισμός Γλώσσας…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Ρύθμιση Τοπικότητας…"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Άνοιγμα Πρόγνωσης Καιρού στον Φυλλομετρητή"
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Άνοιγμα Νέου Συμβάντος στον Φυλλομετρητή"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event Form"
+#~ msgstr "Άνοιγμα Νέας Μορφής Συμβάντος"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM, yyyy"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Άνοιξε το Συμβάν στον Φυλλομετρητή"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Πχ: 9πμ-5μμ Εργασία"
+#~ msgid "Login"
+#~ msgstr "Σύνδεση"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Ο καιρός δεν έχει ρυθμιστεί.\n"
-"Πηγαίνετε στο Καιρός στις ρυθμίσεις του Event Calendar και ορίστε την πόλη "
-"σας,\n"
-"και / ή απενεργοποιήστε το μετεωρογράφημα για να αποκρύψετε αυτήν την "
-"περιοχή."
+#~ msgid "Currently Synched."
+#~ msgstr "Αυτή τη στιγμή είναι συγχρονισμένο."
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr ""
+#~ msgid "Logout"
+#~ msgstr "Αποσύνδεση"
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr ""
+#~ msgid "Tooltip"
+#~ msgstr "Συμβουλή Εργαλείου"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Ο χρονομετρητής τελείωσε"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η κατάργηση της επιλογής Τοπική Ώρα από τη συμβουλή "
+#~ "εργαλείου"
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 έχει παρέλθει"
+#~ msgid "Set Locale…"
+#~ msgstr "Ρύθμιση Τοπικότητας…"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Επανάληψη"
-
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Παύση χρονομετρητή"
-
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Εκκίνηση χρονομετρητή"
-
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Κύλιση ροδέλας για προσθήκη/αφαίρεση στη διάρκεια"
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Ήχος"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr ""
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Εκκίνηση Συμβάντων"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Συμβάντα Σε Εξέλιξη"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Επόμενα Συμβάντα"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Κύλιση ροδέλας για προσθήκη/αφαίρεση στη διάρκεια"
 
 #~ msgid "Choose"
 #~ msgstr "Επιλογή"

--- a/package/translate/es.po
+++ b/package/translate/es.po
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -247,7 +247,7 @@ msgstr "El widget se ha actualizado. Por favor cierra y vuelve a iniciar sesión
 
 #: ../contents/ui/Logic.qml
 msgid "Logged out of Google. Please login again."
-msgstr "Sesión cerrada en Google. Por favor vuelva a iniciar sessión."
+msgstr "Sesión cerrada en Google. Por favor vuelva a iniciar sesión."
 
 #: ../contents/ui/MeteogramView.qml
 #, c-format

--- a/package/translate/es.po
+++ b/package/translate/es.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2017-06-10 HO:MI+ZONE\n"
 "Last-Translator: Kepa Badiola <badiol@yahoo.es>\n"
 "Language-Team: Spanish <LL@li.org>\n"
@@ -17,14 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Calendario de Eventos"
-
-#: ../metadata.desktop
-msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr "Plasmoid para calendario + agenda con información del clima. Sincroniza con Google Calendar."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -46,7 +38,7 @@ msgstr "Calendario"
 msgid "Agenda"
 msgstr "Agenda"
 
-#: ../contents/config/config.qml
+#: ../contents/config/config.qml ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Eventos"
 
@@ -66,9 +58,17 @@ msgstr "Tiempo"
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Todo el Día"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -91,6 +91,18 @@ msgid "Edit in browser"
 msgstr "Editar en navegador"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM d"
@@ -100,39 +112,290 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "MMM d"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Calendario de Eventos"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Sin Calendarios]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d MMM, yyyy"
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "a"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Título del evento"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Todo el Día"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Añade una ubicación"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Agregar descripción"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "Guardar"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Cancelar"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Añadir fecha de vencimiento"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "h AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1h"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr "No se pudo conectar"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "Error HTTP %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr "Intentaremos más tarde."
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Alcanzado límite de la API meteorológica"
+
+#: ../contents/ui/Logic.qml
+msgid "Google authorization expired or was revoked. Open Event Calendar Settings, select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Widget has been updated. Please logout and login to Google Calendar again."
+msgstr "El widget se ha actualizado. Por favor cierra y vuelve a iniciar sesión en Google Calendar"
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Sesión cerrada en Google. Por favor vuelva a iniciar sessión."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "MMMM d, yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM, yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Ej: 9am-5pm Trabajo"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Tiempo no configurado.\n"
+"Vaya a Tiempo en la configuración y establece tu ciudad,\n"
+"y/o deshabilita el meteograma para ocultar este área."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Error al buscar el clima."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Empezar"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Temporizador"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Temporizador terminado"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "Han pasado %1"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Repetir"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Pausar Temporizador"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Empezar Temporizador"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Sonido"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Establecer temporizador"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Comenzando Eventos"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Eventos En Progreso"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Próximos Eventos"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr "Empiezan en %1"
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Sin título)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Sin Calendarios]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "Error HTTP %1: %2"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr "No se pudo conectar"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr "Intentaremos más tarde."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid "Widget has been updated. Please logout and login to Google Calendar again."
-msgstr "El widget se ha actualizado. Por favor cierra y vuelve a iniciar sesión en Google Calendar"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "Demasiadas peticiones web. Intentaremos más tarde."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -179,20 +442,16 @@ msgid "Click Weather:"
 msgstr "Click en Tiempo:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Abrir Open City Forecast en el Navegador"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml ../contents/ui/config/ConfigCalendar.qml
 msgid "Click Date:"
 msgstr "Click en Fecha:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Abrir Nuevo Evento en el Navegador"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Abrir Nuevo Formulario de Eventos"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -211,8 +470,8 @@ msgid "Click Event:"
 msgstr "Click en Evento:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Abrir Eventos en el Navegador"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -290,11 +549,6 @@ msgstr "Estilo"
 msgid "Current Month Title:"
 msgstr "Título del mes actual"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "MMMM d, yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Mostrar Bordes"
@@ -371,6 +625,10 @@ msgstr "Complementos del calendario de eventos"
 msgid "Plasma Calendar Plugins"
 msgstr "Complementos de calendario de plasma"
 
+#: ../contents/ui/config/ConfigEvents.qml
+msgid "Plasma calendar plugins are unavailable. Install the Plasma calendar module to manage these plugins."
+msgstr ""
+
 #: ../contents/ui/config/ConfigEvents.qml ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Misceláneo"
@@ -407,10 +665,6 @@ msgstr "Mostrar/Ocultar elementos gráficos sobre el calendario. Alternar Agenda
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Meteograma"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Temporizador"
 
 #: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/lib/ConfigNotification.qml
 msgid "SFX:"
@@ -509,40 +763,200 @@ msgid "Enable Debugging"
 msgstr "Activar Depuración"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Empezar sesión"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Está Sincronizado."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Terminar sesión"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google login failed because the browser returned an unexpected state token. Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically. Use the login link below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google access for this account expired or was revoked. Use Update Selected below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Using a previously stored Google OAuth client for compatibility. If login still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The built-in Google OAuth client is currently rejected by Google because it requires a client secret. Provide your own client ID and client secret to enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and secret with the redirect URI set to %1. Leaving these empty only works if a previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "For a custom OAuth client, publish the OAuth consent screen to Production. Google expires refresh tokens for external apps left in Testing after seven days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Para sincronizar con Google Calendar"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
-msgstr "Visite <a href=\"%1\">%2</a> (se abre en su navegador web). Después de iniciar sesión y dar permiso para acceder a su calendario, le dará un código para pegar a continuación."
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to a localhost URL. If auto-capture succeeds you can ignore the field below; otherwise copy the full URL (or just the code) and paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to the helper page and will try to send the code back automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Copiar enlace"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Ingrese el código aquí (Ej: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "If your browser shows a connection error, that's expected. Copy the URL from the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture fails, copy the code from the helper page and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Enviar"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Código de autorización de Google no válido"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/config/ConfigICal.qml
 msgid "Calendars"
@@ -589,6 +1003,10 @@ msgid "Calendar Label"
 msgstr "Etiqueta de calendario"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Examinar"
 
@@ -605,12 +1023,44 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Agenda debajo del calendario (Una Columna)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Información sobre herramientas"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "No se puede anular la selección de la hora local de la información sobre herramientas"
+msgid "Enter time zone IDs (for example: Europe/London, America/New_York). The list controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -619,6 +1069,10 @@ msgstr "Datos"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API App Id:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -726,38 +1180,41 @@ msgstr "Página web de la Ciudad"
 msgid "Open Link"
 msgstr "Abrir Enlace"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "a"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Título del evento"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Añade una ubicación"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Agregar descripción"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "Guardar"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Cancelar"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Añadir fecha de vencimiento"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -780,154 +1237,64 @@ msgstr "Archivos de sonido (%1)"
 msgid "All files (%1)"
 msgstr "Todos los archivos (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "h AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1h"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Alcanzado límite de la API meteorológica"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Sesión cerrada en Google. Por favor vuelva a iniciar sessión."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Elegir lenguaje…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Establecer Localización…"
+#~ msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr "Plasmoid para calendario + agenda con información del clima. Sincroniza con Google Calendar."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Abrir Open City Forecast en el Navegador"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Abrir Nuevo Evento en el Navegador"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM, yyyy"
+#~ msgid "Open New Event Form"
+#~ msgstr "Abrir Nuevo Formulario de Eventos"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Ej: 9am-5pm Trabajo"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Abrir Eventos en el Navegador"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Tiempo no configurado.\n"
-"Vaya a Tiempo en la configuración y establece tu ciudad,\n"
-"y/o deshabilita el meteograma para ocultar este área."
+#~ msgid "Login"
+#~ msgstr "Empezar sesión"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Error al buscar el clima."
+#~ msgid "Currently Synched."
+#~ msgstr "Está Sincronizado."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Empezar"
+#~ msgid "Logout"
+#~ msgstr "Terminar sesión"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Temporizador terminado"
+#~ msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
+#~ msgstr "Visite <a href=\"%1\">%2</a> (se abre en su navegador web). Después de iniciar sesión y dar permiso para acceder a su calendario, le dará un código para pegar a continuación."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "Han pasado %1"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Ingrese el código aquí (Ej: %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Repetir"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Código de autorización de Google no válido"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Pausar Temporizador"
+#~ msgid "Tooltip"
+#~ msgstr "Información sobre herramientas"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Empezar Temporizador"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "No se puede anular la selección de la hora local de la información sobre herramientas"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Desplazar para añadir a duración"
+#~ msgid "Set Locale…"
+#~ msgstr "Establecer Localización…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Sonido"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Establecer temporizador"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Comenzando Eventos"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Eventos En Progreso"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Próximos Eventos"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr "Empiezan en %1"
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Desplazar para añadir a duración"
 
 #~ msgid "Weather API limit reached, will try again soon."
 #~ msgstr "Se alcanzó el límite de la API meteorológica, lo intentaremos nuevamente pronto."

--- a/package/translate/fi.po
+++ b/package/translate/fi.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2022-03-21 23:40+ZONE\n"
 "Last-Translator: Ilpo Kantonen <ilpo@iki.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,14 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Language: fi_FI\n"
 "X-Source-Language: C\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Tapahtumakalenteri"
-
-#: ../metadata.desktop
-msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr "Plasmoidi kalenteri + agenda säätietoineen synkronoitu Google Calendarin kanssa."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -48,7 +40,7 @@ msgstr "Kalenteri"
 msgid "Agenda"
 msgstr "Agenda"
 
-#: ../contents/config/config.qml
+#: ../contents/config/config.qml ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Tapahtumat"
 
@@ -68,9 +60,17 @@ msgstr "Sää"
 msgid "Advanced"
 msgstr "Lisäasetukset"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Koko päivä"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -93,6 +93,18 @@ msgid "Edit in browser"
 msgstr "Muokkaa selaimessa"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM-d"
@@ -102,39 +114,290 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "MMM-d"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Tapahtumakalenteri"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Ei kalentereja]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d MMM, yyyy"
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "->"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Tapahtuman otsikko"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Koko päivä"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Lisää paikka"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Lisää kuvaus"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&Talleta"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Keskeytä"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Lisää eräpäivä"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "g AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1 h"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1 m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1 s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr "Ei voitu yhdistää"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "HTTP-virhe %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr "Yhdistää uudelleen pian."
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Sään API-rajoitus saavutettu"
+
+#: ../contents/ui/Logic.qml
+msgid "Google authorization expired or was revoked. Open Event Calendar Settings, select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Widget has been updated. Please logout and login to Google Calendar again."
+msgstr "Kalenteri on päivitetty. Ole hyvä ja kirjaudu Google-kalenteriin uudelleen."
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Kirjauduttu ulos Googlesta. Ole hyvä ja kirjaudu uudelleen."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1 mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "MMMM d, yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM, yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Esim: 9 AP - 5 IP Työ"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Sääasetuksia ei ole tehty.\n"
+"Mene asetuksissa Sää-kohtaan ja aseta kaupunkisi\n"
+"ja/tai estä sääkartan piilottaa tämä alue."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Virhe säätietojen jaussa."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Aloita"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Ajastin"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Ajastin lopetti."
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 on hyväksytty"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Toista"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Tauota ajastin"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Aloita ajastin"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Ääni"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Aseta ajastin"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Tapahtumat alkavat"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Tpaahtumat käynnissä"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Tulevat tapahtumat"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr "Alkaa %1 kuluttua"
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Ei otsikkoa)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Ei kalentereja]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "HTTP-virhe %1: %2"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr "Ei voitu yhdistää"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr "Yhdistää uudelleen pian."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid "Widget has been updated. Please logout and login to Google Calendar again."
-msgstr "Kalenteri on päivitetty. Ole hyvä ja kirjaudu Google-kalenteriin uudelleen."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "Liian monta web-pyyntöä. Yrittää uudelleen hetken kuluttua."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -181,20 +444,16 @@ msgid "Click Weather:"
 msgstr "Napsauta Sää:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Avaa kaupungin sää selaimessa"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml ../contents/ui/config/ConfigCalendar.qml
 msgid "Click Date:"
 msgstr "Napsauta päivä:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Avaa uusi tapahtuma selaimessa"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Avaa uusi tapahtumalomake"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -213,8 +472,8 @@ msgid "Click Event:"
 msgstr "Napsauta tapahtumaa:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Avaa tapahtuma selaimessa"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -292,11 +551,6 @@ msgstr "Tyyli"
 msgid "Current Month Title:"
 msgstr "Nykyinen kuukausi otsikko:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "MMMM d, yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Näytä kehykset"
@@ -373,6 +627,10 @@ msgstr "Tapahumakalenterin liitännäinen"
 msgid "Plasma Calendar Plugins"
 msgstr "Plasma-kalenterin liitännäinen"
 
+#: ../contents/ui/config/ConfigEvents.qml
+msgid "Plasma calendar plugins are unavailable. Install the Plasma calendar module to manage these plugins."
+msgstr ""
+
 #: ../contents/ui/config/ConfigEvents.qml ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Sekalaiset"
@@ -409,10 +667,6 @@ msgstr "Näytä/Piilota tietoja kalenterin edellä. Vaihda Agenda/Kalenteri niid
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Säätila"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Ajastin"
 
 #: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/lib/ConfigNotification.qml
 msgid "SFX:"
@@ -511,40 +765,200 @@ msgid "Enable Debugging"
 msgstr "Salli debuggaus"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Kirjautuminen"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Synkronissa tällä hetkellä."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Uloskirjautuminen"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google login failed because the browser returned an unexpected state token. Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically. Use the login link below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google access for this account expired or was revoked. Use Update Selected below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Using a previously stored Google OAuth client for compatibility. If login still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The built-in Google OAuth client is currently rejected by Google because it requires a client secret. Provide your own client ID and client secret to enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and secret with the redirect URI set to %1. Leaving these empty only works if a previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "For a custom OAuth client, publish the OAuth consent screen to Production. Google expires refresh tokens for external apps left in Testing after seven days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Google-kalenteriin yhdistäminen"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
-msgstr "Mene osoitteeseen <a href=\"%1\">%2</a> (avaa www-selaimeen). Kun olet kirjautunut ja antanut luvat kalenteriisi, sinulle annetaan koodi. Kopioi koodi alle."
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to a localhost URL. If auto-capture succeeds you can ignore the field below; otherwise copy the full URL (or just the code) and paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to the helper page and will try to send the code back automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Kopioi linkki"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Anna koodi tähän (Esim: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "If your browser shows a connection error, that's expected. Copy the URL from the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture fails, copy the code from the helper page and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Lähetä"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Väärä Googlen valtuutuskoodi"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/config/ConfigICal.qml
 msgid "Calendars"
@@ -591,6 +1005,10 @@ msgid "Calendar Label"
 msgstr "Kalenterin otsikko"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Selaa"
 
@@ -607,12 +1025,44 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Agenda kalenterin alle (yksi sarake)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Vihje"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Paikallista aikaa ei voi poistaa työkaluvihjeestä"
+msgid "Enter time zone IDs (for example: Europe/London, America/New_York). The list controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -621,6 +1071,10 @@ msgstr "Tiedot"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API sovelluksen id:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -729,38 +1183,41 @@ msgstr "Kaupungin www-sivu"
 msgid "Open Link"
 msgstr "Avaa linkki"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "->"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Tapahtuman otsikko"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Lisää paikka"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Lisää kuvaus"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&Talleta"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Keskeytä"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Lisää eräpäivä"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -783,151 +1240,61 @@ msgstr "Äänitiedostot (%1)"
 msgid "All files (%1)"
 msgstr "Kaikki tiedostot (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "g AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1 h"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1 m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1 s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Sään API-rajoitus saavutettu"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Kirjauduttu ulos Googlesta. Ole hyvä ja kirjaudu uudelleen."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Aseta kieli…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Aseta paikka…"
+#~ msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr "Plasmoidi kalenteri + agenda säätietoineen synkronoitu Google Calendarin kanssa."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1 mm"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Avaa kaupungin sää selaimessa"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Avaa uusi tapahtuma selaimessa"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM, yyyy"
+#~ msgid "Open New Event Form"
+#~ msgstr "Avaa uusi tapahtumalomake"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Esim: 9 AP - 5 IP Työ"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Avaa tapahtuma selaimessa"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Sääasetuksia ei ole tehty.\n"
-"Mene asetuksissa Sää-kohtaan ja aseta kaupunkisi\n"
-"ja/tai estä sääkartan piilottaa tämä alue."
+#~ msgid "Login"
+#~ msgstr "Kirjautuminen"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Virhe säätietojen jaussa."
+#~ msgid "Currently Synched."
+#~ msgstr "Synkronissa tällä hetkellä."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Aloita"
+#~ msgid "Logout"
+#~ msgstr "Uloskirjautuminen"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Ajastin lopetti."
+#~ msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
+#~ msgstr "Mene osoitteeseen <a href=\"%1\">%2</a> (avaa www-selaimeen). Kun olet kirjautunut ja antanut luvat kalenteriisi, sinulle annetaan koodi. Kopioi koodi alle."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 on hyväksytty"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Anna koodi tähän (Esim: %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Toista"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Väärä Googlen valtuutuskoodi"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Tauota ajastin"
+#~ msgid "Tooltip"
+#~ msgstr "Vihje"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Aloita ajastin"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Paikallista aikaa ei voi poistaa työkaluvihjeestä"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Valitse lisätäksesi keston"
+#~ msgid "Set Locale…"
+#~ msgstr "Aseta paikka…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Ääni"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Aseta ajastin"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Tapahtumat alkavat"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Tpaahtumat käynnissä"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Tulevat tapahtumat"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr "Alkaa %1 kuluttua"
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Valitse lisätäksesi keston"

--- a/package/translate/fi.po
+++ b/package/translate/fi.po
@@ -287,7 +287,7 @@ msgstr ""
 
 #: ../contents/ui/PopupView.qml
 msgid "Error fetching weather."
-msgstr "Virhe säätietojen jaussa."
+msgstr "Virhe säätietojen haussa."
 
 #: ../contents/ui/TimerInputView.qml
 msgid "&Start"
@@ -303,7 +303,7 @@ msgstr "Ajastin lopetti."
 
 #: ../contents/ui/TimerModel.qml
 msgid "%1 has passed"
-msgstr "%1 on hyväksytty"
+msgstr "%1 on kulunut"
 
 #: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
 msgid "Repeat"

--- a/package/translate/fr.po
+++ b/package/translate/fr.po
@@ -282,7 +282,7 @@ msgstr "MMMM, yyyy"
 
 #: ../contents/ui/NewEventForm.qml
 msgid "Eg: 9am-5pm Work"
-msgstr "Ex: 9am-5pm Ouvré"
+msgstr "Ex: 9am-5pm Travail"
 
 #: ../contents/ui/PopupView.qml
 msgid ""

--- a/package/translate/fr.po
+++ b/package/translate/fr.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2019-10-30 13:29+0900\n"
 "Last-Translator: Mathieu Provençal <mth.provencal@gmail.com>\n"
 "Language-Team: French <LL@li.org>\n"
@@ -17,16 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.2.1\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Calendrier des événements"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -49,6 +40,7 @@ msgid "Agenda"
 msgstr "Agenda"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Événements"
 
@@ -68,10 +60,17 @@ msgstr "Météo"
 msgid "Advanced"
 msgstr "Avancé"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Toute la journée"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -94,6 +93,18 @@ msgid "Edit in browser"
 msgstr "Modifier dans le navigateur"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM d"
@@ -103,40 +114,300 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "MMM d"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Calendrier des événements"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Aucun calendrier]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d MMM yyyy"
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "à"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Titre de l'événement"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Toute la journée"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Ajouter un lieu"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Ajouter une description"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&Sauvegarder"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Annuler"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1h"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr ""
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "d MMMM yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM, yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Ex: 9am-5pm Ouvré"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Météo non paramétrée.\n"
+"Aller sélectionner votre ville dans les paramètres Météo,\n"
+"et/ou désactiver l'affichage du météogramme."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Erreur lors de la récupération de la météo"
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Début"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Minuterie"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Minuterie terminée"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 a passé"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Répéter"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Mettre en pause la minuterie"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Démarrer la minuterie"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Son"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Régler la minuterie"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Événements qui débutent"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Événements en cours"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Événements à venir"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Aucun titre)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Aucun calendrier]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr ""
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -186,8 +457,8 @@ msgid "Click Weather:"
 msgstr "Cliquer sur la météo:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Ouvrir le navigateur pour afficher les prévisions"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -195,12 +466,8 @@ msgid "Click Date:"
 msgstr "Cliquer sur la date:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Ouvrir un nouvel événement dans le navigateur"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Ouvrir un nouveau formulaire d'événement"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -219,8 +486,8 @@ msgid "Click Event:"
 msgstr "Cliquer sur l'événement:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Ouverture de l'événement dans le navigateur"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -304,11 +571,6 @@ msgstr "Style"
 msgid "Current Month Title:"
 msgstr ""
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "d MMMM yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Afficher les contours"
@@ -386,6 +648,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Plugins du Calendrier Plasma"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Divers"
@@ -427,10 +695,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Météogramme"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Minuterie"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -541,46 +805,230 @@ msgid "Enable Debugging"
 msgstr "Activer le débogage"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Connexion"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Synchronisé"
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Déconnexion"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Synchroniser avec Google Calendar"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"Visiter <a href=\"%1\">%2</a> (la page s'ouvrira dans votre navigateur). "
-"Après vous êtes connecté et autorisé l'accès à votre calendrier, vous aurez "
-"un code que vous pourrez coller ci-dessous."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Copier le lien"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Entrez le code ici (Ex: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Soumettre"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Code d'autorisation Google invalide"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -628,6 +1076,10 @@ msgid "Calendar Label"
 msgstr "Étiquette"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Naviguer"
 
@@ -644,12 +1096,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Info-bulle"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Impossible de désélectionner l'heure locale dans l'info-bulle"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -658,6 +1144,10 @@ msgstr "Données"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API Ajouter Id:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -772,38 +1262,40 @@ msgstr "Page web de la ville"
 msgid "Open Link"
 msgstr "Ouvrir le lien"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d MMM yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "à"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Titre de l'événement"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Ajouter un lieu"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Ajouter une description"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&Sauvegarder"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Annuler"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
 msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
@@ -827,154 +1319,67 @@ msgstr ""
 msgid "All files (%1)"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1h"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr ""
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Régler la langue…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Paramètres régionaux…"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Ouvrir le navigateur pour afficher les prévisions"
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Ouvrir un nouvel événement dans le navigateur"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event Form"
+#~ msgstr "Ouvrir un nouveau formulaire d'événement"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM, yyyy"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Ouverture de l'événement dans le navigateur"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Ex: 9am-5pm Ouvré"
+#~ msgid "Login"
+#~ msgstr "Connexion"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Météo non paramétrée.\n"
-"Aller sélectionner votre ville dans les paramètres Météo,\n"
-"et/ou désactiver l'affichage du météogramme."
+#~ msgid "Currently Synched."
+#~ msgstr "Synchronisé"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Erreur lors de la récupération de la météo"
+#~ msgid "Logout"
+#~ msgstr "Déconnexion"
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Début"
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "Visiter <a href=\"%1\">%2</a> (la page s'ouvrira dans votre navigateur). "
+#~ "Après vous êtes connecté et autorisé l'accès à votre calendrier, vous "
+#~ "aurez un code que vous pourrez coller ci-dessous."
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Minuterie terminée"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Entrez le code ici (Ex: %1)"
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 a passé"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Code d'autorisation Google invalide"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Répéter"
+#~ msgid "Tooltip"
+#~ msgstr "Info-bulle"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Mettre en pause la minuterie"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Impossible de désélectionner l'heure locale dans l'info-bulle"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Démarrer la minuterie"
+#~ msgid "Set Locale…"
+#~ msgstr "Paramètres régionaux…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Faites défiler pour ajouter à la durée"
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Son"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Régler la minuterie"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Événements qui débutent"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Événements en cours"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Événements à venir"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Faites défiler pour ajouter à la durée"
 
 #~ msgid "Weather API limit reached, will try again soon."
 #~ msgstr "Limite de l'API atteinte, essayer plus tard"
@@ -1013,8 +1418,8 @@ msgstr ""
 #~ "Enter the following code at <a href=\"https://www.google.com/"
 #~ "device\">https://www.google.com/device</a>."
 #~ msgstr ""
-#~ "Entrer le code sur <a href=\"https://www.google.com/device\">https://www."
-#~ "google.com/device</a>."
+#~ "Entrer le code sur <a href=\"https://www.google.com/device\">https://"
+#~ "www.google.com/device</a>."
 
 #~ msgid "Generating Code…"
 #~ msgstr "Génération du code…"

--- a/package/translate/he.po
+++ b/package/translate/he.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2022-04-05 00:34+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,18 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n==2 ? 1 : n>10 && n%10==0 ? "
 "2 : 3);\n"
 "X-Generator: Poedit 3.0.1\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "לוח שנה עם אירועים"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
-"יישומון לוח שנה וסדר יום שמסתנכרן עם Google Calendar ועם גישה ישירה לתחזית "
-"מזג האוויר."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -52,6 +41,7 @@ msgid "Agenda"
 msgstr "סדר יום"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "אירועים"
 
@@ -71,10 +61,17 @@ msgstr "מזג האוויר"
 msgid "Advanced"
 msgstr "מתקדם"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "כל היום"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -97,6 +94,18 @@ msgid "Edit in browser"
 msgstr "עריכה בדפדפן"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "d ב־MMM"
@@ -106,41 +115,301 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "d ב־MMM"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "לוח שנה עם אירועים"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[אין לוחות שנה]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d ב־MMM, yyyy"
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "עד"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "כותרת האירוע"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "כל היום"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "הוספת מיקום"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "הוספת תיאור"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&שמירה"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "בי_טול"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "הוספת תאריך יעד"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "h AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1 שע׳"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1 דק׳"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1 שנ׳"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr "לא היה ניתן להתחבר"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "שגיאת HTTP‏ %1:‏ %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr "ננסה שוב בקרוב."
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "הגעת למכסת ה־API של תחזית מזג האוויר"
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr "היישומון עודכן. נא לצאת ולהיכנס בחזרה אל Google Calendar."
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "מחוץ לחשבון Google. נא להיכנס שוב."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1 מ״מ"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "ה־d MMMM, yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM, yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "למשל: עבודה בשעות 9:00-‏17:00"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"לא הוגדרה תחזית מזג האוויר.\n"
+"יש לבחור בלשונית מזג האוויר במסך ההגדרה ולבחור את העיר שלך,\n"
+"ו/או להשבית את תחזית מזג האוויר כדי להסתיר את האזור הזה."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "שגיאה במשיכת תחזית מזג האוויר."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "ה&תחלה"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "טיימר"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "הטיימר הסתיים"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 עבר"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "חזרה"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "השהיית הטיימר"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "התחלת הטיימר"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "צליל"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "הגדרת טיימר"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "אירועים שמתחילים"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "אירועים שמתרחשים כעת"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "אירועים קרובים"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr "מתחיל בעוד %1"
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(אין כותרת)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[אין לוחות שנה]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "שגיאת HTTP‏ %1:‏ %2"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr "לא היה ניתן להתחבר"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr "ננסה שוב בקרוב."
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr "היישומון עודכן. נא לצאת ולהיכנס בחזרה אל Google Calendar."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "יותר מדי בקשות. ננסה שוב בקרוב."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -189,8 +458,8 @@ msgid "Click Weather:"
 msgstr "לחיצה על מזג האוויר:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "פתיחת התחזית לעיר בדפדפן"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -198,12 +467,8 @@ msgid "Click Date:"
 msgstr "לחיצה על תאריך:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "פתיחת אירוע חדש בדפדפן"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "פתיחת דו־שיח מקומי ליצירת אירועים"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -222,8 +487,8 @@ msgid "Click Event:"
 msgstr "לחיצה על אירוע:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "פתיחת האירוע בדפדפן"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -303,11 +568,6 @@ msgstr "סגנון"
 msgid "Current Month Title:"
 msgstr "כותרת החודש הנוכחי:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "ה־d MMMM, yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "הצגת גבולות"
@@ -385,6 +645,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "תוספי לוח שנה ל־‏Plasma"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "שונות"
@@ -426,10 +692,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "תחזית"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "טיימר"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -537,45 +799,230 @@ msgid "Enable Debugging"
 msgstr "הפעלת ניפוי שגיאות"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "כניסה"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "כרגע מסונכרן."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "יציאה"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "לסנכרון עם Google Calendar"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"נא לפתוח את <a href=\"%1\">%2</a> (הקישור ייפתח בדפדפן האינטרנט). לאחר "
-"הכניסה והענקת הרשאת הגישה ללוח השנה, יינתן לך קוד שיהיה אפשר להדביק למטה."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "העתקת הקישור"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "נא לציין את הקוד כאן (למשל: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "שליחה"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "קוד בלתי־תקין של Google Authorization"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -623,6 +1070,10 @@ msgid "Calendar Label"
 msgstr "תווית לוח שנה"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "עיון"
 
@@ -639,12 +1090,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "סדר היום מתחת ללוח השנה (עמודה אחת)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "חלונית הגדרה"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "לא ניתן לבטל את בחירת הזמן המקומי מתוך חלונית ההגדרות"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -653,6 +1138,10 @@ msgstr "נתונים"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "מזהה ה־API של היישום:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -769,39 +1258,41 @@ msgstr "אתר האינטרנט של העיר"
 msgid "Open Link"
 msgstr "פתיחת הקישור"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d ב־MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "עד"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "כותרת האירוע"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "הוספת מיקום"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "הוספת תיאור"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&שמירה"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "בי_טול"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "הוספת תאריך יעד"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -824,151 +1315,69 @@ msgstr "קובצי שמע (%1)"
 msgid "All files (%1)"
 msgstr "כל הקבצים (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "h AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1 שע׳"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1 דק׳"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1 שנ׳"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "הגעת למכסת ה־API של תחזית מזג האוויר"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "מחוץ לחשבון Google. נא להיכנס שוב."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "הגדרת שפה…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "הגדרת מיקום…"
+#~ msgid ""
+#~ "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr ""
+#~ "יישומון לוח שנה וסדר יום שמסתנכרן עם Google Calendar ועם גישה ישירה "
+#~ "לתחזית מזג האוויר."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1 מ״מ"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "פתיחת התחזית לעיר בדפדפן"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "פתיחת אירוע חדש בדפדפן"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM, yyyy"
+#~ msgid "Open New Event Form"
+#~ msgstr "פתיחת דו־שיח מקומי ליצירת אירועים"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "למשל: עבודה בשעות 9:00-‏17:00"
+#~ msgid "Open Event In Browser"
+#~ msgstr "פתיחת האירוע בדפדפן"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"לא הוגדרה תחזית מזג האוויר.\n"
-"יש לבחור בלשונית מזג האוויר במסך ההגדרה ולבחור את העיר שלך,\n"
-"ו/או להשבית את תחזית מזג האוויר כדי להסתיר את האזור הזה."
+#~ msgid "Login"
+#~ msgstr "כניסה"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "שגיאה במשיכת תחזית מזג האוויר."
+#~ msgid "Currently Synched."
+#~ msgstr "כרגע מסונכרן."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "ה&תחלה"
+#~ msgid "Logout"
+#~ msgstr "יציאה"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "הטיימר הסתיים"
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "נא לפתוח את <a href=\"%1\">%2</a> (הקישור ייפתח בדפדפן האינטרנט). לאחר "
+#~ "הכניסה והענקת הרשאת הגישה ללוח השנה, יינתן לך קוד שיהיה אפשר להדביק למטה."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 עבר"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "נא לציין את הקוד כאן (למשל: %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "חזרה"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "קוד בלתי־תקין של Google Authorization"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "השהיית הטיימר"
+#~ msgid "Tooltip"
+#~ msgstr "חלונית הגדרה"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "התחלת הטיימר"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "לא ניתן לבטל את בחירת הזמן המקומי מתוך חלונית ההגדרות"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "יש לגלול כדי להוסיף משך זמן"
+#~ msgid "Set Locale…"
+#~ msgstr "הגדרת מיקום…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "צליל"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "הגדרת טיימר"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "אירועים שמתחילים"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "אירועים שמתרחשים כעת"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "אירועים קרובים"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr "מתחיל בעוד %1"
+#~ msgid "Scroll to add to duration"
+#~ msgstr "יש לגלול כדי להוסיף משך זמן"

--- a/package/translate/it.po
+++ b/package/translate/it.po
@@ -15,7 +15,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../contents/config/config.qml
 msgid "General"

--- a/package/translate/it.po
+++ b/package/translate/it.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2020-11-12 19:45+0100\n"
 "Last-Translator: Guido Mazzone <guido.mazzone93@outlook.it>\n"
 "Language-Team: Italian <guido.mazzone93@outlook.it>\n"
@@ -16,14 +16,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Calendario Eventi"
-
-#: ../metadata.desktop
-msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr "Plasmoide per un calendario+agenda con meteo che si sincronizza con Google Calendar."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -45,7 +37,7 @@ msgstr "Calendario"
 msgid "Agenda"
 msgstr "Agenda"
 
-#: ../contents/config/config.qml
+#: ../contents/config/config.qml ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Eventi"
 
@@ -65,9 +57,17 @@ msgstr "Meteo"
 msgid "Advanced"
 msgstr "Avanzato"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Tutto il giorno"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -90,6 +90,18 @@ msgid "Edit in browser"
 msgstr "Modifica nel browser"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "d MMM"
@@ -99,39 +111,290 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "d MMM"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Calendario Eventi"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Nessun Calendario]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d MMM yyyy"
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "fino al"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Titolo evento"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Tutto il giorno"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Aggiungi luogo"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Aggiungi descrizione"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&Salva"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Cancella"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Aggiungi data scadenza"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "h AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1h"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr "Impossibile connettersi"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "Errore HTTP %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr "Riproverò a breve"
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Raggiunto il limite dell'API del meteo"
+
+#: ../contents/ui/Logic.qml
+msgid "Google authorization expired or was revoked. Open Event Calendar Settings, select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Widget has been updated. Please logout and login to Google Calendar again."
+msgstr "Il widget è stato agiornato. Sei invitato a disconnetterti e riconnennetterti a Google Calendar."
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Disconnesso da Google. Sei invitato a riconnetterti."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "d MMMM yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Es: 9am-5pm Lavoro"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Meteo non configurato.\n"
+"Vai al meteo nella configurazione e imposta la tua città,\n"
+"e/o disabilita il meteogramma per nascondere quest'area."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Errore nello scaricamento del meteo."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Avvia"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Timer"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Tempo scaduto"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "Sono passati %1"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Ripeti"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Sospendi timer"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Avvia timer"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Suono"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Imposta timer"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Eventi in partenza"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Eventi in corso"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Eventi imminenti"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr "Partenza tra %1"
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(nessun titolo)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Nessun Calendario]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "Errore HTTP %1: %2"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr "Impossibile connettersi"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr "Riproverò a breve"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid "Widget has been updated. Please logout and login to Google Calendar again."
-msgstr "Il widget è stato agiornato. Sei invitato a disconnetterti e riconnennetterti a Google Calendar."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "Troppe richieste web. Riproverò a breve."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -178,20 +441,16 @@ msgid "Click Weather:"
 msgstr "Click sul meteo:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Apri le previsioni della città nel browser"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml ../contents/ui/config/ConfigCalendar.qml
 msgid "Click Date:"
 msgstr "Click su una data:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Apri nuovo evento nel browser"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Apri modulo per il nuovo evento"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -210,8 +469,8 @@ msgid "Click Event:"
 msgstr "Click su un evento:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Apri evento nel browser"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -289,11 +548,6 @@ msgstr "Stile"
 msgid "Current Month Title:"
 msgstr "Titolo del mese corrente:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "d MMMM yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Mostra i bordi"
@@ -370,6 +624,10 @@ msgstr "Lista plugin calendario eventi"
 msgid "Plasma Calendar Plugins"
 msgstr "Lista plugin calendario Plasma"
 
+#: ../contents/ui/config/ConfigEvents.qml
+msgid "Plasma calendar plugins are unavailable. Install the Plasma calendar module to manage these plugins."
+msgstr ""
+
 #: ../contents/ui/config/ConfigEvents.qml ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Altro"
@@ -406,10 +664,6 @@ msgstr "Mostra/nascondi i widget sopra il calendario. Attiva Agenda/Calendario n
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Meteogramma"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Timer"
 
 #: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/lib/ConfigNotification.qml
 msgid "SFX:"
@@ -508,40 +762,200 @@ msgid "Enable Debugging"
 msgstr "Abilita debugging"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Entra"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Attualmente sincronizzato."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Esci"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google login failed because the browser returned an unexpected state token. Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically. Use the login link below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google access for this account expired or was revoked. Use Update Selected below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Using a previously stored Google OAuth client for compatibility. If login still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The built-in Google OAuth client is currently rejected by Google because it requires a client secret. Provide your own client ID and client secret to enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and secret with the redirect URI set to %1. Leaving these empty only works if a previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "For a custom OAuth client, publish the OAuth consent screen to Production. Google expires refresh tokens for external apps left in Testing after seven days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Per sincronizzare con Google Calendar"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
-msgstr "Visita <a href=\"%1\">%2</a> (si apre nel tuo browser web). Dopo che sei entrato e hai dato il permesso per accedere al tuo calendario, ti darà un codice da incollare qui sotto."
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to a localhost URL. If auto-capture succeeds you can ignore the field below; otherwise copy the full URL (or just the code) and paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to the helper page and will try to send the code back automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Copia link"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Inserisci il codice qui (es: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "If your browser shows a connection error, that's expected. Copy the URL from the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture fails, copy the code from the helper page and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Invia"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Codice di autorizzazione Google non valido"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/config/ConfigICal.qml
 msgid "Calendars"
@@ -588,6 +1002,10 @@ msgid "Calendar Label"
 msgstr "Etichetta del calendario"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Naviga"
 
@@ -604,12 +1022,44 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Agenda sotto il calendario (colonna singola)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Consiglio"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Non è possibile deselezionare l'orario locale dal consiglio"
+msgid "Enter time zone IDs (for example: Europe/London, America/New_York). The list controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -618,6 +1068,10 @@ msgstr "Dati"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "Id API app:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -725,38 +1179,41 @@ msgstr "Pagina web della città"
 msgid "Open Link"
 msgstr "Apri link"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d MMM yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "fino al"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Titolo evento"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Aggiungi luogo"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Aggiungi descrizione"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&Salva"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Cancella"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Aggiungi data scadenza"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -779,154 +1236,64 @@ msgstr "File sonori (%1)"
 msgid "All files (%1)"
 msgstr "Tutti i file (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "h AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1h"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Raggiunto il limite dell'API del meteo"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Disconnesso da Google. Sei invitato a riconnetterti."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Imposta lingua…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Imposta località…"
+#~ msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr "Plasmoide per un calendario+agenda con meteo che si sincronizza con Google Calendar."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Apri le previsioni della città nel browser"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Apri nuovo evento nel browser"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM yyyy"
+#~ msgid "Open New Event Form"
+#~ msgstr "Apri modulo per il nuovo evento"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Es: 9am-5pm Lavoro"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Apri evento nel browser"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Meteo non configurato.\n"
-"Vai al meteo nella configurazione e imposta la tua città,\n"
-"e/o disabilita il meteogramma per nascondere quest'area."
+#~ msgid "Login"
+#~ msgstr "Entra"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Errore nello scaricamento del meteo."
+#~ msgid "Currently Synched."
+#~ msgstr "Attualmente sincronizzato."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Avvia"
+#~ msgid "Logout"
+#~ msgstr "Esci"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Tempo scaduto"
+#~ msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
+#~ msgstr "Visita <a href=\"%1\">%2</a> (si apre nel tuo browser web). Dopo che sei entrato e hai dato il permesso per accedere al tuo calendario, ti darà un codice da incollare qui sotto."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "Sono passati %1"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Inserisci il codice qui (es: %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Ripeti"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Codice di autorizzazione Google non valido"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Sospendi timer"
+#~ msgid "Tooltip"
+#~ msgstr "Consiglio"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Avvia timer"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Non è possibile deselezionare l'orario locale dal consiglio"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Scorri per aumentare o diminuire la durata"
+#~ msgid "Set Locale…"
+#~ msgstr "Imposta località…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Suono"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Imposta timer"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Eventi in partenza"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Eventi in corso"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Eventi imminenti"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr "Partenza tra %1"
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Scorri per aumentare o diminuire la durata"
 
 #~ msgid "Could not connect (HTTP Error 0), will try again soon."
 #~ msgstr "Impossibile connettersi (errore HTTP 0), riproverò a breve."

--- a/package/translate/ja.po
+++ b/package/translate/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: yamato kobayashi <Kb_yamato@protonmail.com>\n"
 "Language-Team: \n"
@@ -16,14 +16,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "イベントカレンダー"
-
-#: ../metadata.desktop
-msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -45,7 +37,7 @@ msgstr "カレンダー"
 msgid "Agenda"
 msgstr "予定"
 
-#: ../contents/config/config.qml
+#: ../contents/config/config.qml ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "イベント"
 
@@ -65,9 +57,17 @@ msgstr "天気"
 msgid "Advanced"
 msgstr "高度"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "1日"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -90,6 +90,18 @@ msgid "Edit in browser"
 msgstr "ブラウザーで編集"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "M月 d日"
@@ -99,38 +111,289 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd曜日"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "M月 d日"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "イベントカレンダー"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[カレンダーはありません]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "M月 d日, yyyy"
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "から"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "イベントタイトル"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "1日"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "地域を追加"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "概要を追加"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "＆保存"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "＆キャンセル"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Google authorization expired or was revoked. Open Event Calendar Settings, select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr ""
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "M月 d日 yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "例：9am-5pm 仕事"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"天気が設定されていません\n"
+"天気の設定に行き都市を設定してください\n"
+"又はこのエリアでの天気予報を無効にしてください"
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "エラー天気を取得できませんでした。"
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "＆スタート"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "タイマー"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "タイマーが終了"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "リピート"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "タイマーを一時停止"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "タイマーをスタート"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "音"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "タイマーセット"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "イベント開始しました"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "イベントは実行中"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "今後のイベント"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(無題)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[カレンダーはありません]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Too many web requests. Will try again soon."
 msgstr ""
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid "Widget has been updated. Please logout and login to Google Calendar again."
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
 msgstr ""
 
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-msgid "Too many web requests. Will try again soon."
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -178,20 +441,16 @@ msgid "Click Weather:"
 msgstr "天気をクリック"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "天気予報をブラウザーで開く"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml ../contents/ui/config/ConfigCalendar.qml
 msgid "Click Date:"
 msgstr "日付をクリック"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "新しいイベントをブラウザーで開く"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "新しいイベントフォーム"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -210,8 +469,8 @@ msgid "Click Event:"
 msgstr "イベントクリック："
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "イベントをブラウザーで開く"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -289,11 +548,6 @@ msgstr "スタイル"
 msgid "Current Month Title:"
 msgstr ""
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "M月 d日 yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "境界を表示"
@@ -370,6 +624,10 @@ msgstr "Event Calendar プラグイン"
 msgid "Plasma Calendar Plugins"
 msgstr "Plasma カレンダープラグイン"
 
+#: ../contents/ui/config/ConfigEvents.qml
+msgid "Plasma calendar plugins are unavailable. Install the Plasma calendar module to manage these plugins."
+msgstr ""
+
 #: ../contents/ui/config/ConfigEvents.qml ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "その他"
@@ -408,10 +666,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "天気予報マップ"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "タイマー"
 
 #: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/lib/ConfigNotification.qml
 msgid "SFX:"
@@ -510,40 +764,200 @@ msgid "Enable Debugging"
 msgstr "デバッグを有効化"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "ログイン"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "現在同期されています"
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "ログアウト"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google login failed because the browser returned an unexpected state token. Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically. Use the login link below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google access for this account expired or was revoked. Use Update Selected below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Using a previously stored Google OAuth client for compatibility. If login still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The built-in Google OAuth client is currently rejected by Google because it requires a client secret. Provide your own client ID and client secret to enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and secret with the redirect URI set to %1. Leaving these empty only works if a previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "For a custom OAuth client, publish the OAuth consent screen to Production. Google expires refresh tokens for external apps left in Testing after seven days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Google Calendarと同期します"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
-msgstr " <a href=\"%1\">%2</a> (ウェブブラウザーで開く)。 カレンダーへのアクセスを許可してください、 以下に貼り付けるコードが表示されます。"
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to a localhost URL. If auto-capture succeeds you can ignore the field below; otherwise copy the full URL (or just the code) and paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to the helper page and will try to send the code back automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "リンクをコピー"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "コードを個々に記入してください(Eg: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "If your browser shows a connection error, that's expected. Copy the URL from the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture fails, copy the code from the helper page and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "参加"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Google Authorization Codeが無効です"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/config/ConfigICal.qml
 msgid "Calendars"
@@ -590,6 +1004,10 @@ msgid "Calendar Label"
 msgstr "カレンダーラベル"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "ブラウズ"
 
@@ -606,12 +1024,44 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "カレンダーの下に予定を配置（1列）"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "選択する"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "現地時間が必要です"
+msgid "Enter time zone IDs (for example: Europe/London, America/New_York). The list controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -620,6 +1070,10 @@ msgstr "データ"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API App Id:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -727,37 +1181,40 @@ msgstr "都市のサイト"
 msgid "Open Link"
 msgstr "リンクを開く"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "M月 d日, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "から"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "イベントタイトル"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "地域を追加"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "概要を追加"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "＆保存"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "＆キャンセル"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
 msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
@@ -781,154 +1238,61 @@ msgstr "サウンドファイル (%1)"
 msgid "All files (%1)"
 msgstr "全てのファイル (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr ""
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "言語を選択"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "地域を選択"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "天気予報をブラウザーで開く"
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr ""
+#~ msgid "Open New Event In Browser"
+#~ msgstr "新しいイベントをブラウザーで開く"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr ""
+#~ msgid "Open New Event Form"
+#~ msgstr "新しいイベントフォーム"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr ""
+#~ msgid "Open Event In Browser"
+#~ msgstr "イベントをブラウザーで開く"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "例：9am-5pm 仕事"
+#~ msgid "Login"
+#~ msgstr "ログイン"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"天気が設定されていません\n"
-"天気の設定に行き都市を設定してください\n"
-"又はこのエリアでの天気予報を無効にしてください"
+#~ msgid "Currently Synched."
+#~ msgstr "現在同期されています"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "エラー天気を取得できませんでした。"
+#~ msgid "Logout"
+#~ msgstr "ログアウト"
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "＆スタート"
+#~ msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
+#~ msgstr " <a href=\"%1\">%2</a> (ウェブブラウザーで開く)。 カレンダーへのアクセスを許可してください、 以下に貼り付けるコードが表示されます。"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "タイマーが終了"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "コードを個々に記入してください(Eg: %1)"
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr ""
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Google Authorization Codeが無効です"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "リピート"
+#~ msgid "Tooltip"
+#~ msgstr "選択する"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "タイマーを一時停止"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "現地時間が必要です"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "タイマーをスタート"
+#~ msgid "Set Locale…"
+#~ msgstr "地域を選択"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "スクロール期間を追加"
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "音"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "タイマーセット"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "イベント開始しました"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "イベントは実行中"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "今後のイベント"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "スクロール期間を追加"
 
 #~ msgid "Could not connect (HTTP Error 0), will try again soon."
 #~ msgstr "接続できません (HTTP Error 0)、まもなく再接続されます。"

--- a/package/translate/ja.po
+++ b/package/translate/ja.po
@@ -15,7 +15,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -151,7 +151,7 @@ msgstr "イベントタイトル"
 
 #: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
 msgid "All Day"
-msgstr "1日"
+msgstr "終日"
 
 #: ../contents/ui/EditEventForm.qml
 msgid "Add location"
@@ -1107,7 +1107,6 @@ msgstr "天気予報を"
 msgid " hour"
 msgid_plural " hours"
 msgstr[0] "時間"
-msgstr[1] "時間"
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid " in the meteogram."

--- a/package/translate/ko.po
+++ b/package/translate/ko.po
@@ -283,7 +283,7 @@ msgstr "yyyy년 MMMM"
 
 #: ../contents/ui/NewEventForm.qml
 msgid "Eg: 9am-5pm Work"
-msgstr "예: 오전 9시 - 오전 5시 직장"
+msgstr "예: 오전 9시 - 오후 5시 근무"
 
 #: ../contents/ui/PopupView.qml
 msgid ""

--- a/package/translate/ko.po
+++ b/package/translate/ko.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2022-10-25 17:15+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,17 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.1.1\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "이벤트 달력"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
-"Google 캘린더랑 동기화할 수 있는 달력, 일정 및 날씨 Plasmoid 위젯입니다."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -50,6 +40,7 @@ msgid "Agenda"
 msgstr "일정"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "행사"
 
@@ -69,10 +60,17 @@ msgstr "날씨"
 msgid "Advanced"
 msgstr "고급"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "하루 종일"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -95,6 +93,18 @@ msgid "Edit in browser"
 msgstr "브라우저에서 편집"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM d일"
@@ -104,42 +114,302 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "MMM d일"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "이벤트 달력"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[달력 없음]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "yyyy년 MMM d일"
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "이벤트 제목"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "하루 종일"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "위치 추가"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "설명 추가"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "저장(&S)"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "취소(&C)"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "기한 추가"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h시"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "AP h시"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "AP h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1시간"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr "연결 실패"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "HTTP 오류 %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr "나중에 다시 시도하십시오."
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "날씨 API의 제한에 도달하였습니다"
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+"위젯이 업데이트되었습니다. Google 캘린더에 로그아웃 후 다시 로그인하십시오."
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Google에 로그아웃되었습니다. 다시 로그인하십시오."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "yyyy년 MMMM d일"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "yyyy년 MMMM"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "예: 오전 9시 - 오전 5시 직장"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"날씨가 설정되지 않았습니다.\n"
+"설정 창의 날씨 항목에서 도시를 설정하십시오.\n"
+"천문 현상을 비활성화하셔도 됩니다."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "날씨 확인에 실패하였습니다."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "시작(&S)"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "타이머"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "타이머 완료"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 초과"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "반복"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "타이머 일시정지"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "타이머 시작"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "소리"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "타이머 설정"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "이벤트 시작"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "진행 중인 이벤트"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "예정된 이벤트"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr "%1부터 시작"
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(제목 없음)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[달력 없음]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "HTTP 오류 %1: %2"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr "연결 실패"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr "나중에 다시 시도하십시오."
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr ""
-"위젯이 업데이트되었습니다. Google 캘린더에 로그아웃 후 다시 로그인하십시오."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "웹 요청이 너무 많습니다. 나중에 다시 시도하십시오."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -188,8 +458,8 @@ msgid "Click Weather:"
 msgstr "날씨 클릭:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "브라우저에서 도시 날씨 열기"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -197,12 +467,8 @@ msgid "Click Date:"
 msgstr "날짜 클릭:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "브라우저에서 새 이벤트 열기"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "새 이벤트 창 열기"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -221,8 +487,8 @@ msgid "Click Event:"
 msgstr "이벤트 클릭:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "브라우저에서 이벤트 열기"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -302,11 +568,6 @@ msgstr "스타일"
 msgid "Current Month Title:"
 msgstr "이번 달 제목:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "yyyy년 MMMM d일"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "윤곽선 표시"
@@ -384,6 +645,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Plasma 달력 플러그인"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "그 외"
@@ -423,10 +690,6 @@ msgstr "달력 밑에 위젯을 표시하거나 숨깁니다."
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "천문 현상"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "타이머"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -533,45 +796,230 @@ msgid "Enable Debugging"
 msgstr "디버깅 사용"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "로그인"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "동기화되었습니다."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "로그아웃"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Google 캘린더랑 동기화"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"<a href=\"%1\">%2</a>으로 가십시오 (웹 브라우저에서 열림). 로그인 후 달력 접"
-"근 권한을 부여하시면 이곳으로 복사할 코드가 주어집니다."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "링크 복사"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "코드 입력 (예: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "제출"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "잘못된 Google 인증 코드"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -619,6 +1067,10 @@ msgid "Calendar Label"
 msgstr "달력 이름"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "찾기"
 
@@ -635,12 +1087,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "일정 밑에 달력 표시 (한 줄)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "툴팁"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "툴팁에서 지역 시간 선택을 해제할 수 없음"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -649,6 +1135,10 @@ msgstr "데이터"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API 앱 ID:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -762,39 +1252,41 @@ msgstr "도시 웹페이지"
 msgid "Open Link"
 msgstr "링크 열기"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "yyyy년 MMM d일"
-
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "이벤트 제목"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "위치 추가"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "설명 추가"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "저장(&S)"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "취소(&C)"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "기한 추가"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -817,151 +1309,65 @@ msgstr "소리 파일 (%1)"
 msgid "All files (%1)"
 msgstr "모든 파일 (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h시"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "AP h시"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "AP h:mm"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1시간"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "날씨 API의 제한에 도달하였습니다"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Google에 로그아웃되었습니다. 다시 로그인하십시오."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "언어 설정…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "지역 설정…"
+#~ msgid ""
+#~ "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr ""
+#~ "Google 캘린더랑 동기화할 수 있는 달력, 일정 및 날씨 Plasmoid 위젯입니다."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "브라우저에서 도시 날씨 열기"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "브라우저에서 새 이벤트 열기"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "yyyy년 MMMM"
+#~ msgid "Open New Event Form"
+#~ msgstr "새 이벤트 창 열기"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "예: 오전 9시 - 오전 5시 직장"
+#~ msgid "Open Event In Browser"
+#~ msgstr "브라우저에서 이벤트 열기"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"날씨가 설정되지 않았습니다.\n"
-"설정 창의 날씨 항목에서 도시를 설정하십시오.\n"
-"천문 현상을 비활성화하셔도 됩니다."
+#~ msgid "Login"
+#~ msgstr "로그인"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "날씨 확인에 실패하였습니다."
+#~ msgid "Currently Synched."
+#~ msgstr "동기화되었습니다."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "시작(&S)"
+#~ msgid "Logout"
+#~ msgstr "로그아웃"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "타이머 완료"
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "<a href=\"%1\">%2</a>으로 가십시오 (웹 브라우저에서 열림). 로그인 후 달력 "
+#~ "접근 권한을 부여하시면 이곳으로 복사할 코드가 주어집니다."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 초과"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "코드 입력 (예: %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "반복"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "잘못된 Google 인증 코드"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "타이머 일시정지"
+#~ msgid "Tooltip"
+#~ msgstr "툴팁"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "타이머 시작"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "툴팁에서 지역 시간 선택을 해제할 수 없음"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr ""
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "소리"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "타이머 설정"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "이벤트 시작"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "진행 중인 이벤트"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "예정된 이벤트"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr "%1부터 시작"
+#~ msgid "Set Locale…"
+#~ msgstr "지역 설정…"

--- a/package/translate/merge
+++ b/package/translate/merge
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
+if [ -z "${BASH_VERSION:-}" ]; then
+	exec /usr/bin/env bash "$0" "$@"
+fi
 # Version: 23
 
 # https://techbase.kde.org/Development/Tutorials/Localization/i18n_Build_Systems
@@ -30,17 +33,16 @@ widgetName="${plasmoidName##*.}" # Strip namespace
 website=$(read_metadata "KPlugin.Website")
 bugAddress="$website"
 packageRoot=".." # Root of translatable sources
-projectName="plasma_applet_${plasmoidName}" # project name
 
 ### Colors
 # https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux
 # https://stackoverflow.com/questions/911168/how-can-i-detect-if-my-shell-script-is-running-through-a-pipe
-TC_Red='\033[31m'; TC_Orange='\033[33m';
-TC_LightGray='\033[90m'; TC_LightRed='\033[91m'; TC_LightGreen='\033[92m'; TC_Yellow='\033[93m'; TC_LightBlue='\033[94m';
+TC_Red='\033[31m';
+TC_LightGray='\033[90m'; TC_LightGreen='\033[92m';
 TC_Reset='\033[0m'; TC_Bold='\033[1m';
 if [ ! -t 1 ]; then
-	TC_Red=''; TC_Orange='';
-	TC_LightGray=''; TC_LightRed=''; TC_LightGreen=''; TC_Yellow=''; TC_LightBlue='';
+	TC_Red='';
+	TC_LightGray=''; TC_LightGreen='';
 	TC_Bold=''; TC_Reset='';
 fi
 function echoTC() {
@@ -153,7 +155,7 @@ else
 	mv "template.pot.new" "template.pot"
 fi
 
-potMessageCount=`expr $(grep -Pzo 'msgstr ""\n(\n|$)' "template.pot" | grep -c 'msgstr ""')`
+potMessageCount=$(grep -Pzo 'msgstr ""\n(\n|$)' "template.pot" | grep -c 'msgstr ""')
 echo "|  Locale  |  Lines  | % Done|" > "./Status.md"
 echo "|----------|---------|-------|" >> "./Status.md"
 entryFormat="| %-8s | %7s | %5s |"
@@ -201,7 +203,7 @@ for cat in $catalogs; do
 	sed -i 's/# Translation of '"${widgetName}"' in LANGUAGE/'"# Translation of ${widgetName} in ${catLocale}"'/' "$cat.new"
 	sed -i 's/# Copyright (C) YEAR THE PACKAGE'"'"'S COPYRIGHT HOLDER/'"# Copyright (C) $(date +%Y)"'/' "$cat.new"
 
-	poEmptyMessageCount=`expr $(grep -Pzo 'msgstr ""\n(\n|$)' "$cat.new" | grep -c 'msgstr ""')`
+	poEmptyMessageCount=$(grep -Pzo 'msgstr ""\n(\n|$)' "$cat.new" | grep -c 'msgstr ""')
 	poMessagesDoneCount=`expr $potMessageCount - $poEmptyMessageCount`
 	poCompletion=`perl -e "printf(\"%d\", $poMessagesDoneCount * 100 / $potMessageCount)"`
 	poLine=`perl -e "printf(\"$entryFormat\", \"$catLocale\", \"${poMessagesDoneCount}/${potMessageCount}\", \"${poCompletion}%\")"`

--- a/package/translate/merge
+++ b/package/translate/merge
@@ -98,7 +98,16 @@ fi
 # We don't need -kN_ since we don't use intltool-extract but might as well keep it.
 # I have no idea what -kaliasLocale is used for. Googling aliasLocale found only listed kde1 code.
 # We don't need to parse -ki18nd since that'll extract messages from other domains.
-find "${packageRoot}" -name '*.cpp' -o -name '*.h' -o -name '*.c' -o -name '*.qml' -o -name '*.js' | sort > "${DIR}/infiles.list"
+: > "${DIR}/infiles.list"
+while IFS= read -r sourceFile; do
+	if grep -Eq '(i18n|ki18n|xi18n|I18N_NOOP|tr2i18n|tr2xi18n|N_)[[:alnum:]_]*[[:space:]]*\(' "$sourceFile"; then
+		printf '%s\n' "$sourceFile" >> "${DIR}/infiles.list"
+	fi
+done < <(
+	find "${packageRoot}" -type f \
+		\( -name '*.cpp' -o -name '*.h' -o -name '*.c' -o -name '*.qml' -o -name '*.js' \) \
+		| sort
+)
 xgettext \
 	${potArgs} \
 	--files-from="${DIR}/infiles.list" \

--- a/package/translate/nl.po
+++ b/package/translate/nl.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2022-04-05 13:49+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <>\n"
@@ -17,18 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 22.03.80\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Afsprakenboek"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
-"Een plasmoid met kalender, agenda en weer die synchroniseert met Google "
-"Agenda."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -51,6 +40,7 @@ msgid "Agenda"
 msgstr "Agenda"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Afspraken"
 
@@ -70,10 +60,17 @@ msgstr "Weer"
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Hele dag"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -96,6 +93,18 @@ msgid "Edit in browser"
 msgstr "Aanpassen in webbrowser"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "d MMM"
@@ -105,41 +114,301 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "d MMM"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Afsprakenboek"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Geen agenda's]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d MMM yyyy"
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "tot"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Titel"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Hele dag"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Locatie toevoegen"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Omschrijving toevoegen"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "Op&slaan"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Annuleren"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Einddatum toevoegen"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "h AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1u"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr "Er kan geen verbinding worden gemaakt"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "Http-fout %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr "Het wordt spoedig opnieuw geprobeerd."
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Het api-limiet van de weerdienst is bereikt"
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr "De widget is bijgewerkt. Log uit en weer in op Google Agenda."
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Je bent uitgelogd - log opnieuw in."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "d MMMM yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Bijv.: 9-17: werk"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Het weer is niet ingesteld.\n"
+"Open de pagina ‘Weer’ in de instellingen en stel een locatie in\n"
+"of schakel de weergrafiek uit om deze sectie te verbergen."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "De weerinformatie kan niet worden opgevraagd."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Starten"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Tijdklok"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Tijdklok verstreken"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 is verstreken"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Herhalen"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Tijdklok onderbreken"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Tijdklok starten"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Geluid"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Tijdklok instellen"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Aankomende afspraken"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Lopende afspraken"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Ingeplande afspraken"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr "Begint over %1"
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(naamloos)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Geen agenda's]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "Http-fout %1: %2"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr "Er kan geen verbinding worden gemaakt"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr "Het wordt spoedig opnieuw geprobeerd."
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr "De widget is bijgewerkt. Log uit en weer in op Google Agenda."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "Er waren teveel verzoeken - het wordt spoedig opnieuw geprobeerd."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -188,8 +457,8 @@ msgid "Click Weather:"
 msgstr "Actie na aanklikken van weer:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Weersvoorspelling openen in webbrowser"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -197,12 +466,8 @@ msgid "Click Date:"
 msgstr "Actie na aanklikken van datum:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Nieuwe afspraak openen in webbrowser"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Nieuwe afspraak openen in pop-up"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -221,8 +486,8 @@ msgid "Click Event:"
 msgstr "Actie na aanklikken van afspraak:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Afspraak openen in webbrowser"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -302,11 +567,6 @@ msgstr "Stijl"
 msgid "Current Month Title:"
 msgstr "Naam van huidige maand:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "d MMMM yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Kaders tonen"
@@ -384,6 +644,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Plasma-kalenderuitbreidingen"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Overig"
@@ -425,10 +691,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Weergrafiek"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Tijdklok"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -538,46 +800,230 @@ msgid "Enable Debugging"
 msgstr "Foutopsporing inschakelen"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Inloggen"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Alles is gesynchroniseerd."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Uitloggen"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Synchroniseren met Google Agenda"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"Ga naar <a href=\"%1\">%2</a> (de link opent in je browser), log in en "
-"verleen de vereiste machtiging. Kopieer daarna de door Google getoonde code "
-"en plak deze hieronder."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Link kopiëren"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Voer hier de code in (bijv.: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Versturen"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Ongeldige verificatiecode"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -625,6 +1071,10 @@ msgid "Calendar Label"
 msgstr "Agendalabel"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Bladeren"
 
@@ -641,12 +1091,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Agenda onder kalender tonen (één kolom)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Hulpballon"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "De lokale tijd kan niet worden gedeselecteerd in de hulpballon"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -655,6 +1139,10 @@ msgstr "Gegevens"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API App-id:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -769,39 +1257,41 @@ msgstr "Webpagina"
 msgid "Open Link"
 msgstr "Link openen"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d MMM yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "tot"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Titel"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Locatie toevoegen"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Omschrijving toevoegen"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "Op&slaan"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Annuleren"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Einddatum toevoegen"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -824,154 +1314,73 @@ msgstr "Geluidsbestanden (%1)"
 msgid "All files (%1)"
 msgstr "Alle bestanden (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "h AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1u"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Het api-limiet van de weerdienst is bereikt"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Je bent uitgelogd - log opnieuw in."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Taal instellen…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Regionale instellingen…"
+#~ msgid ""
+#~ "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr ""
+#~ "Een plasmoid met kalender, agenda en weer die synchroniseert met Google "
+#~ "Agenda."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Weersvoorspelling openen in webbrowser"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Nieuwe afspraak openen in webbrowser"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM yyyy"
+#~ msgid "Open New Event Form"
+#~ msgstr "Nieuwe afspraak openen in pop-up"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Bijv.: 9-17: werk"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Afspraak openen in webbrowser"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Het weer is niet ingesteld.\n"
-"Open de pagina ‘Weer’ in de instellingen en stel een locatie in\n"
-"of schakel de weergrafiek uit om deze sectie te verbergen."
+#~ msgid "Login"
+#~ msgstr "Inloggen"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "De weerinformatie kan niet worden opgevraagd."
+#~ msgid "Currently Synched."
+#~ msgstr "Alles is gesynchroniseerd."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Starten"
+#~ msgid "Logout"
+#~ msgstr "Uitloggen"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Tijdklok verstreken"
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "Ga naar <a href=\"%1\">%2</a> (de link opent in je browser), log in en "
+#~ "verleen de vereiste machtiging. Kopieer daarna de door Google getoonde "
+#~ "code en plak deze hieronder."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 is verstreken"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Voer hier de code in (bijv.: %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Herhalen"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Ongeldige verificatiecode"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Tijdklok onderbreken"
+#~ msgid "Tooltip"
+#~ msgstr "Hulpballon"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Tijdklok starten"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "De lokale tijd kan niet worden gedeselecteerd in de hulpballon"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Scroll om de duur te verlengen"
+#~ msgid "Set Locale…"
+#~ msgstr "Regionale instellingen…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Geluid"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Tijdklok instellen"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Aankomende afspraken"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Lopende afspraken"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Ingeplande afspraken"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr "Begint over %1"
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Scroll om de duur te verlengen"
 
 #~ msgid "Could not connect (HTTP Error 0), will try again soon."
 #~ msgstr ""

--- a/package/translate/pl.po
+++ b/package/translate/pl.po
@@ -14,7 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -1105,6 +1106,7 @@ msgid " hour"
 msgid_plural " hours"
 msgstr[0] " godzin"
 msgstr[1] " godzin"
+msgstr[2] " godzin"
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid " in the meteogram."

--- a/package/translate/pl.po
+++ b/package/translate/pl.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2018-09-03 HO:MI+ZONE\n"
 "Last-Translator: Jakub Starzyk <jstarzyk98@gmail.com>\n"
 "Language-Team: Jakub Starzyk <jstarzyk98@gmail.com>\n"
@@ -15,14 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr ""
-
-#: ../metadata.desktop
-msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -44,7 +36,7 @@ msgstr "Kalendarz"
 msgid "Agenda"
 msgstr "Harmonogram"
 
-#: ../contents/config/config.qml
+#: ../contents/config/config.qml ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Wydarzenia"
 
@@ -64,9 +56,17 @@ msgstr "Pogoda"
 msgid "Advanced"
 msgstr "Zaawansowane"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Cały dzień"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -89,6 +89,18 @@ msgid "Edit in browser"
 msgstr "Edytuj w przeglądarce"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "d MMM"
@@ -98,38 +110,289 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "d MMM"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr ""
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Brak kalendarzy]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "do"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Cały dzień"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "Zapisz"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "Anuluj"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Google authorization expired or was revoked. Open Event Calendar Settings, select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr ""
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1 mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "d MMMM yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Np.: 9-17 Praca"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Pogoda nie jest skonfigurowana.\n"
+"Przejdź do zakładki Pogoda w ustawieniach i wybierz miasto\n"
+"i/lub wyłącz wykres prognozy pogody, by ukryć ten obszar."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr ""
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Minutnik"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Minutnik zakończył odmierzanie"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "Upłynęło %1"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Powtarzaj"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Zatrzymaj minutnik"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Uruchom minutnik"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Dźwięk"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Ustaw minutnik"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Wydarzenia zaczynające się"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Trwające wydarzenia"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Nadchodzące wydarzenia"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Brak tytułu)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Brak kalendarzy]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Too many web requests. Will try again soon."
 msgstr ""
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid "Widget has been updated. Please logout and login to Google Calendar again."
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
 msgstr ""
 
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-msgid "Too many web requests. Will try again soon."
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -177,20 +440,16 @@ msgid "Click Weather:"
 msgstr "Kliknięcie ikony pogody:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Otwórz prognozę pogody w przeglądarce"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml ../contents/ui/config/ConfigCalendar.qml
 msgid "Click Date:"
 msgstr "Kliknięcie daty:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Otwórz nowe wydarzenie w przeglądarce"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Otwórz formularz nowego wydarzenia"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -209,8 +468,8 @@ msgid "Click Event:"
 msgstr "Kliknięcie wydarzenia:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Otwórz wydarzenie w przeglądarce"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -288,11 +547,6 @@ msgstr "Styl"
 msgid "Current Month Title:"
 msgstr ""
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "d MMMM yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Pokaż obramowanie"
@@ -369,6 +623,10 @@ msgstr "Wtyczki Event Calendar"
 msgid "Plasma Calendar Plugins"
 msgstr "Wtyczki kalendarza Plazmy"
 
+#: ../contents/ui/config/ConfigEvents.qml
+msgid "Plasma calendar plugins are unavailable. Install the Plasma calendar module to manage these plugins."
+msgstr ""
+
 #: ../contents/ui/config/ConfigEvents.qml ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Różne"
@@ -405,10 +663,6 @@ msgstr "Pokaż/ukryj elementy interfejsu nad kalendarzem. Przełączaj harmonogr
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Wykres prognozy pogody"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Minutnik"
 
 #: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/lib/ConfigNotification.qml
 msgid "SFX:"
@@ -507,23 +761,151 @@ msgid "Enable Debugging"
 msgstr "Włącz debugowanie"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Logowanie"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Zsynchronizowane."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Wyloguj się"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google login failed because the browser returned an unexpected state token. Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically. Use the login link below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google access for this account expired or was revoked. Use Update Selected below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Using a previously stored Google OAuth client for compatibility. If login still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The built-in Google OAuth client is currently rejected by Google because it requires a client secret. Provide your own client ID and client secret to enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and secret with the redirect URI set to %1. Leaving these empty only works if a previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "For a custom OAuth client, publish the OAuth consent screen to Production. Google expires refresh tokens for external apps left in Testing after seven days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Aby zsynchronizować z Kalendarzem Google"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to a localhost URL. If auto-capture succeeds you can ignore the field below; otherwise copy the full URL (or just the code) and paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to the helper page and will try to send the code back automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -531,7 +913,39 @@ msgid "Copy Link"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "If your browser shows a connection error, that's expected. Copy the URL from the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture fails, copy the code from the helper page and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -539,7 +953,7 @@ msgid "Submit"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
+msgid "Update Selected"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/config/ConfigICal.qml
@@ -587,6 +1001,10 @@ msgid "Calendar Label"
 msgstr "Etykieta kalendarza"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Przeglądaj"
 
@@ -603,11 +1021,43 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
+msgid "Local"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
+msgid "Enter time zone IDs (for example: Europe/London, America/New_York). The list controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
 msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
@@ -616,6 +1066,10 @@ msgstr "Dane"
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
 msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
@@ -724,37 +1178,40 @@ msgstr "Strona miasta"
 msgid "Open Link"
 msgstr "Otwórz łącze"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "do"
-
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "Zapisz"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "Anuluj"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
 msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
@@ -778,154 +1235,46 @@ msgstr ""
 msgid "All files (%1)"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr ""
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Ustaw język…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Ustaw formaty…"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Otwórz prognozę pogody w przeglądarce"
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1 mm"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Otwórz nowe wydarzenie w przeglądarce"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event Form"
+#~ msgstr "Otwórz formularz nowego wydarzenia"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM yyyy"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Otwórz wydarzenie w przeglądarce"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Np.: 9-17 Praca"
+#~ msgid "Login"
+#~ msgstr "Logowanie"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Pogoda nie jest skonfigurowana.\n"
-"Przejdź do zakładki Pogoda w ustawieniach i wybierz miasto\n"
-"i/lub wyłącz wykres prognozy pogody, by ukryć ten obszar."
+#~ msgid "Currently Synched."
+#~ msgstr "Zsynchronizowane."
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr ""
+#~ msgid "Logout"
+#~ msgstr "Wyloguj się"
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr ""
+#~ msgid "Set Locale…"
+#~ msgstr "Ustaw formaty…"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Minutnik zakończył odmierzanie"
-
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "Upłynęło %1"
-
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Powtarzaj"
-
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Zatrzymaj minutnik"
-
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Uruchom minutnik"
-
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Przewiń, by zmienić czas odmierzania"
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Dźwięk"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Ustaw minutnik"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Wydarzenia zaczynające się"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Trwające wydarzenia"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Nadchodzące wydarzenia"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Przewiń, by zmienić czas odmierzania"
 
 #~ msgid "Choose"
 #~ msgstr "Wybierz"

--- a/package/translate/pt_BR.po
+++ b/package/translate/pt_BR.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2021-10-19 20:30-0300\n"
 "Last-Translator: Bernardo Barzotto Zomer <bernardobarzottoz@gmail.com>\n"
 "Language-Team: Portuguese <kde-i18n-pt_BR@kde.org>\n"
@@ -17,18 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Lokalize 19.12.2\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Calendário de eventos"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
-"Plasmoide para um calendário e agenda com informações do clima que "
-"sincroniza com o Google Agenda."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -51,6 +40,7 @@ msgid "Agenda"
 msgstr "Agenda"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Eventos"
 
@@ -70,10 +60,17 @@ msgstr "Clima"
 msgid "Advanced"
 msgstr "Avançado"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Dia Inteiro"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -96,6 +93,18 @@ msgid "Edit in browser"
 msgstr "Editar no navegador"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM d"
@@ -105,43 +114,303 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "MMM d"
 
-#: ../contents/ui/calendars/CalendarManager.qml
-msgctxt "event with no summary"
-msgid "(No title)"
-msgstr "(Sem título)"
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Calendário de eventos"
 
 #: ../contents/ui/CalendarSelector.qml
 msgid "[No Calendars]"
 msgstr "[Não há Calendários]"
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "Erro HTTP %1: %2"
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d MMM, yyyy"
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "Para"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Título do Evento"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Dia Inteiro"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Incluir local"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Incluir descrição"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&Salvar"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Cancelar"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Adicionar data de vencimento"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "h AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1h"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Could not connect"
 msgstr "Não foi possível conectar."
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "Erro HTTP %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Will try again soon."
 msgstr "Uma nova tentativa será feita em breve."
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Limite da API do clima alcançada"
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid ""
 "Widget has been updated. Please logout and login to Google Calendar again."
 msgstr ""
 "O widget foi atualizado. Por favor se desconecte do Google Agenda e então "
 "entre novamente."
 
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Você se desconectou do Google. Por favor entre novamente."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "MMMM d, yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM, yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Ex.: 09:00-17:00 Trabalho"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Clima não configurado.\n"
+"Vá para a configuração de clima e configure sua cidade,\n"
+"e/ou desative o meteograma para esconder este campo."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Erro obtendo dados do clima."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Iniciar"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Cronômetro"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "O cronômetro terminou"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 já passou"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Repetir"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Pausar o Cronômetro"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Iniciar o Cronômetro"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Som"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Configurar o Cronômetro"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Eventos Iniciados"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Eventos em Andamento"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Próximos Eventos"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr "Começando em %1"
+
+#: ../contents/ui/calendars/CalendarManager.qml
+msgctxt "event with no summary"
+msgid "(No title)"
+msgstr "(Sem título)"
+
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "Muitos pedidos web. Uma nova tentativa será feita em breve."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -190,8 +459,8 @@ msgid "Click Weather:"
 msgstr "Clicar no Clima:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Abre a previsão para a cidade no navegador"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -199,12 +468,8 @@ msgid "Click Date:"
 msgstr "Clicar na Data:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Abre Novo Evento no Navegador"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Abre Novo Evento"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -223,8 +488,8 @@ msgid "Click Event:"
 msgstr "Clicar no Evento:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Abre o Evento no Navegador"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -304,11 +569,6 @@ msgstr "Estilo"
 msgid "Current Month Title:"
 msgstr "Título do Mês Atual:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "MMMM d, yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Mostrar Bordas"
@@ -386,6 +646,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Plugins do Calendário do Plasma"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Diversos"
@@ -427,10 +693,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Meteograma"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Cronômetro"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -541,46 +803,230 @@ msgid "Enable Debugging"
 msgstr "Ativar depuração"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Logar"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Você está sincronizado."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Sair"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Sincronizar com o Google Calendar"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"Visite <a href=\"%1\">%2</a> (abrirá no seu navegador). Após logar e dar "
-"permissão de acesso ao seu calendário, você irá receber um código para colar "
-"abaixo."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Copiar Link"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Escreva o código aqui (Ex: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Enviar"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Código de Autorização do Google Inválido"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -628,6 +1074,10 @@ msgid "Calendar Label"
 msgstr "Nome do Calendário"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Navegar"
 
@@ -644,12 +1094,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Agenda abaixo do Calendário (Uma Coluna)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Dica de contexto"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Não é possível desmarcar Hora local da dica de contexto"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -658,6 +1142,10 @@ msgstr "Dados"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API App Id:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -772,39 +1260,41 @@ msgstr "Página Web da Cidade"
 msgid "Open Link"
 msgstr "Abir Link"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "Para"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Título do Evento"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Incluir local"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Incluir descrição"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&Salvar"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Cancelar"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Adicionar data de vencimento"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -827,154 +1317,73 @@ msgstr "Arquivos de áudio (%1)"
 msgid "All files (%1)"
 msgstr "Todos arquivos (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "h AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1h"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Limite da API do clima alcançada"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Você se desconectou do Google. Por favor entre novamente."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Definir idioma…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Definir Formato…"
+#~ msgid ""
+#~ "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr ""
+#~ "Plasmoide para um calendário e agenda com informações do clima que "
+#~ "sincroniza com o Google Agenda."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Abre a previsão para a cidade no navegador"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Abre Novo Evento no Navegador"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM, yyyy"
+#~ msgid "Open New Event Form"
+#~ msgstr "Abre Novo Evento"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Ex.: 09:00-17:00 Trabalho"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Abre o Evento no Navegador"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Clima não configurado.\n"
-"Vá para a configuração de clima e configure sua cidade,\n"
-"e/ou desative o meteograma para esconder este campo."
+#~ msgid "Login"
+#~ msgstr "Logar"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Erro obtendo dados do clima."
+#~ msgid "Currently Synched."
+#~ msgstr "Você está sincronizado."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Iniciar"
+#~ msgid "Logout"
+#~ msgstr "Sair"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "O cronômetro terminou"
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "Visite <a href=\"%1\">%2</a> (abrirá no seu navegador). Após logar e dar "
+#~ "permissão de acesso ao seu calendário, você irá receber um código para "
+#~ "colar abaixo."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 já passou"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Escreva o código aqui (Ex: %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Repetir"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Código de Autorização do Google Inválido"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Pausar o Cronômetro"
+#~ msgid "Tooltip"
+#~ msgstr "Dica de contexto"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Iniciar o Cronômetro"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Não é possível desmarcar Hora local da dica de contexto"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Gire a roda do mouse para aumentar a duração"
+#~ msgid "Set Locale…"
+#~ msgstr "Definir Formato…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Som"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Configurar o Cronômetro"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Eventos Iniciados"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Eventos em Andamento"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Próximos Eventos"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr "Começando em %1"
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Gire a roda do mouse para aumentar a duração"
 
 #~ msgid "Weather API limit reached, will try again soon."
 #~ msgstr ""

--- a/package/translate/pt_PT.po
+++ b/package/translate/pt_PT.po
@@ -224,7 +224,7 @@ msgstr "Não foi possível conectar"
 
 #: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "HTTP Error %1: %2"
-msgstr "HTTP Erro %1: %2"
+msgstr "Erro HTTP %1: %2"
 
 #: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Will try again soon."

--- a/package/translate/pt_PT.po
+++ b/package/translate/pt_PT.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2021-03-16 12:00-0500\n"
 "Last-Translator: DMMLeal <dmleal.doc@gmail.com>\n"
 "Language: pt_PT\n"
@@ -14,14 +14,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Calendário de eventos"
-
-#: ../metadata.desktop
-msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr "Plasmoid para um calendário+agenda com Meteorologia que sincroniza com o Calendário Google."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -43,7 +35,7 @@ msgstr "Calendário"
 msgid "Agenda"
 msgstr "Agenda"
 
-#: ../contents/config/config.qml
+#: ../contents/config/config.qml ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Eventos"
 
@@ -63,9 +55,17 @@ msgstr "Meteorologia"
 msgid "Advanced"
 msgstr "Avançado"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Todo o dia"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -88,6 +88,18 @@ msgid "Edit in browser"
 msgstr "Editar no navegador"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM d"
@@ -97,39 +109,290 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "MMM d"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Calendário de eventos"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Não há calendários]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d MMM, yyyy"
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "para"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Título do evento"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Todo o dia"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Adicionar local"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Adicionar descrição"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&Salvar"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Cancelar"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Adicionar data de vencimento"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "h AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1h"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr "Não foi possível conectar"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "HTTP Erro %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr "Tentaremos novamente em breve."
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Atingido o limite de Weather API"
+
+#: ../contents/ui/Logic.qml
+msgid "Google authorization expired or was revoked. Open Event Calendar Settings, select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Widget has been updated. Please logout and login to Google Calendar again."
+msgstr "O aplicativo foi atualizado. Saia e volte a entrar no calendário Google novamente."
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Desconectado do Google. Por favor faça login novamente."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "MMMM d, yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM, yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Ex.: 09:00-17:00 Trabalho"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Meteorologia não configurada.\n"
+"Vá para à configuração da Meteorologia e configure sua cidade,\n"
+"e/ou desative o meteorograma para esconder este campo."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Erro ao obter dados da Meteorologia"
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Iniciar"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Temporizador"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "O Temporizador terminou"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 já passou"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Repetir"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Suspender o Temporizador"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Iniciar Temporizador"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Som"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Configurar o Temporizador"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Eventos iniciados"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Eventos em andamento"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Próximos Eventos"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr "Começando em %1"
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Sem título)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Não há calendários]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "HTTP Erro %1: %2"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr "Não foi possível conectar"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr "Tentaremos novamente em breve."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid "Widget has been updated. Please logout and login to Google Calendar again."
-msgstr "O aplicativo foi atualizado. Saia e volte a entrar no calendário Google novamente."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "Muitos pedidos da internet. Tentaremos novamente em breve."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -176,20 +439,16 @@ msgid "Click Weather:"
 msgstr "Clicar na Meteorologia:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Abra a previsão para a cidade no navegador"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml ../contents/ui/config/ConfigCalendar.qml
 msgid "Click Date:"
 msgstr "Clique na Data"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Abrir um novo evento no navegador"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Abra um novo evento"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -208,8 +467,8 @@ msgid "Click Event:"
 msgstr "Clicar no Evento:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Abrir evento no navegador"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -287,11 +546,6 @@ msgstr "Estilo"
 msgid "Current Month Title:"
 msgstr "Nome do mês atual:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "MMMM d, yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Mostrar bordas"
@@ -368,6 +622,10 @@ msgstr "Plugins do calendário de eventos"
 msgid "Plasma Calendar Plugins"
 msgstr "Plugins do Calendário do Plasma"
 
+#: ../contents/ui/config/ConfigEvents.qml
+msgid "Plasma calendar plugins are unavailable. Install the Plasma calendar module to manage these plugins."
+msgstr ""
+
 #: ../contents/ui/config/ConfigEvents.qml ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Diversos"
@@ -404,10 +662,6 @@ msgstr "Mostrar ou ocultar funções extras acima do calendário. Alternar entre
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Meteorograma"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Temporizador"
 
 #: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/lib/ConfigNotification.qml
 msgid "SFX:"
@@ -506,40 +760,200 @@ msgid "Enable Debugging"
 msgstr "Ativar depuração"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Conectar"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Atualmente sincronizado."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Sair"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google login failed because the browser returned an unexpected state token. Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically. Use the login link below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google access for this account expired or was revoked. Use Update Selected below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Using a previously stored Google OAuth client for compatibility. If login still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The built-in Google OAuth client is currently rejected by Google because it requires a client secret. Provide your own client ID and client secret to enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and secret with the redirect URI set to %1. Leaving these empty only works if a previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "For a custom OAuth client, publish the OAuth consent screen to Production. Google expires refresh tokens for external apps left in Testing after seven days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Sincronizar com o calendário Google"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
-msgstr "Visite <a href=\"%1\">%2</a> (abra o seu navegador de internet). Depois de fazer o login e dar permissão para aceder ao seu calendário, ser-lhe-à dado um código para colar abaixo."
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to a localhost URL. If auto-capture succeeds you can ignore the field below; otherwise copy the full URL (or just the code) and paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to the helper page and will try to send the code back automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Copiar link"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Escreva o código aqui (Ex.: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "If your browser shows a connection error, that's expected. Copy the URL from the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture fails, copy the code from the helper page and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Enviar"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Código de autorização da Google inválido"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/config/ConfigICal.qml
 msgid "Calendars"
@@ -586,6 +1000,10 @@ msgid "Calendar Label"
 msgstr "Nome do calendário"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Navegar"
 
@@ -602,12 +1020,44 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Calendário abaixo da Agenda (coluna única)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Dica de contexto"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Não é possível desmarcar Hora local da dica de contexto"
+msgid "Enter time zone IDs (for example: Europe/London, America/New_York). The list controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -616,6 +1066,10 @@ msgstr "Dados"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API App Id:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -723,38 +1177,41 @@ msgstr "Página web da cidade"
 msgid "Open Link"
 msgstr "Abrir link"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "para"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Título do evento"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Adicionar local"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Adicionar descrição"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&Salvar"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Cancelar"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Adicionar data de vencimento"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -777,151 +1234,61 @@ msgstr "Arquivos de som (%1)"
 msgid "All files (%1)"
 msgstr "Todos os arquivos (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "h AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1h"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Atingido o limite de Weather API"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Desconectado do Google. Por favor faça login novamente."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Definir idioma…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Definir local…"
+#~ msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr "Plasmoid para um calendário+agenda com Meteorologia que sincroniza com o Calendário Google."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Abra a previsão para a cidade no navegador"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Abrir um novo evento no navegador"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM, yyyy"
+#~ msgid "Open New Event Form"
+#~ msgstr "Abra um novo evento"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Ex.: 09:00-17:00 Trabalho"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Abrir evento no navegador"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Meteorologia não configurada.\n"
-"Vá para à configuração da Meteorologia e configure sua cidade,\n"
-"e/ou desative o meteorograma para esconder este campo."
+#~ msgid "Login"
+#~ msgstr "Conectar"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Erro ao obter dados da Meteorologia"
+#~ msgid "Currently Synched."
+#~ msgstr "Atualmente sincronizado."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Iniciar"
+#~ msgid "Logout"
+#~ msgstr "Sair"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "O Temporizador terminou"
+#~ msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
+#~ msgstr "Visite <a href=\"%1\">%2</a> (abra o seu navegador de internet). Depois de fazer o login e dar permissão para aceder ao seu calendário, ser-lhe-à dado um código para colar abaixo."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 já passou"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Escreva o código aqui (Ex.: %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Repetir"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Código de autorização da Google inválido"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Suspender o Temporizador"
+#~ msgid "Tooltip"
+#~ msgstr "Dica de contexto"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Iniciar Temporizador"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Não é possível desmarcar Hora local da dica de contexto"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Gire a roda do rato para aumentar a duração"
+#~ msgid "Set Locale…"
+#~ msgstr "Definir local…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Som"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Configurar o Temporizador"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Eventos iniciados"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Eventos em andamento"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Próximos Eventos"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr "Começando em %1"
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Gire a roda do rato para aumentar a duração"

--- a/package/translate/ru.po
+++ b/package/translate/ru.po
@@ -8,8 +8,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2020-01-05 22:01+0300\n"
 "Last-Translator: aliger14 <aliger14@mail.ru>\n"
 "Language-Team: ru\n"
@@ -20,16 +21,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.2.3\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Календарь событий"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr "Календарь событий с погодой и синхронизацией с Google Calendar."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -52,6 +43,7 @@ msgid "Agenda"
 msgstr "Обзор дня"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "События"
 
@@ -71,10 +63,17 @@ msgstr "Погода"
 msgid "Advanced"
 msgstr "Расширенные"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Весь день"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -97,6 +96,18 @@ msgid "Edit in browser"
 msgstr "Редактировать в браузере"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM d"
@@ -106,43 +117,303 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "MMM d"
 
-#: ../contents/ui/calendars/CalendarManager.qml
-msgctxt "event with no summary"
-msgid "(No title)"
-msgstr "(Без названия)"
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Календарь событий"
 
 #: ../contents/ui/CalendarSelector.qml
 msgid "[No Calendars]"
 msgstr "[Без календарей]"
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "Ошибка соединения %1: %2"
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr "d MMM, yyyy"
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "до"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Название мероприятия"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Весь день"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Добавить местоположение"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Добавить описание"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&Сохранить"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Отменить"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Добавить дату окончания"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "h AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1h"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1m"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1s"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Could not connect"
 msgstr "Невозможно установить соединение"
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "Ошибка соединения %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Will try again soon."
 msgstr "Чуть позже повторим."
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Лимит API по запросам"
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid ""
 "Widget has been updated. Please logout and login to Google Calendar again."
 msgstr ""
 "Виджет был обновлен. Выйдите из учетной записи Google Calendar и войдите "
 "снова."
 
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Произведен выход из Google. Войдите снова."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "d MMMM, yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM, yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Например: 9am-5pm работа"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Погода не настроена.\n"
+"Перейдите в раздел «Погода» и установите своё местоположение,\n"
+"или отключите метеограмму, чтобы скрыть эту область."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Ошибка получения погоды."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr "&Пуск"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Таймер"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Таймер - Стоп"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 прошло"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Повтор"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Таймер-Пауза"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Таймер-Пуск"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Звук"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Выставить таймер"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Начало событий"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Текущие события"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Ближайшие события"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr ""
+
+#: ../contents/ui/calendars/CalendarManager.qml
+msgctxt "event with no summary"
+msgid "(No title)"
+msgstr "(Без названия)"
+
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "Слишком много запросов. Чуть позже повторим."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -191,8 +462,8 @@ msgid "Click Weather:"
 msgstr "Клик по значку погоды:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Открыть прогноз места в браузере"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -200,12 +471,8 @@ msgid "Click Date:"
 msgstr "Клик по дате:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Открыть новое событие в браузере"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Открыть форму нового события"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -224,8 +491,8 @@ msgid "Click Event:"
 msgstr "Клик по событию:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Открыть событие в браузере"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -305,11 +572,6 @@ msgstr "Стиль"
 msgid "Current Month Title:"
 msgstr "Заголовок текущего месяца:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "d MMMM, yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Показать сетку"
@@ -387,6 +649,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Плагины календаря Plasma"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Разное"
@@ -428,10 +696,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Метеограмма"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Таймер"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -542,46 +806,230 @@ msgid "Enable Debugging"
 msgstr "Включить отладку"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Авторизация"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "В настоящее время синхронизировано."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Выйти"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Синхронизация с календарём Google"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"Посетите <a href=\"%1\">%2</a> (открывается в вашем веб-браузере). После "
-"того, как вы войдёте в систему и дадите разрешение на доступ к своему "
-"календарю, он даст вам код для вставки ниже."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Копировать ссылку"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Введите код сюда (Например: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Отправить"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Неверный код Google авторизации"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -630,6 +1078,10 @@ msgid "Calendar Label"
 msgstr "Ярлык календаря"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Обзор"
 
@@ -646,12 +1098,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Распорядок под календарем (Одна колонка)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Подсказка"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Невозможно отменить локальное время из всплывающей подсказки"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -660,6 +1146,10 @@ msgstr "Данные"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API Id приложения:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -775,39 +1265,41 @@ msgstr "Веб-сайт города"
 msgid "Open Link"
 msgstr "Открыть ссылку"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
-msgstr "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
+msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "до"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Название мероприятия"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Добавить местоположение"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Добавить описание"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&Сохранить"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Отменить"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Добавить дату окончания"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -830,154 +1322,71 @@ msgstr "Звуковой файл (%1)"
 msgid "All files (%1)"
 msgstr "Все файлы (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
+msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "h AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1h"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1m"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1s"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Лимит API по запросам"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Произведен выход из Google. Войдите снова."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Установить язык…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Установить локаль …"
+#~ msgid ""
+#~ "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr "Календарь событий с погодой и синхронизацией с Google Calendar."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Открыть прогноз места в браузере"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Открыть новое событие в браузере"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM, yyyy"
+#~ msgid "Open New Event Form"
+#~ msgstr "Открыть форму нового события"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Например: 9am-5pm работа"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Открыть событие в браузере"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Погода не настроена.\n"
-"Перейдите в раздел «Погода» и установите своё местоположение,\n"
-"или отключите метеограмму, чтобы скрыть эту область."
+#~ msgid "Login"
+#~ msgstr "Авторизация"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Ошибка получения погоды."
+#~ msgid "Currently Synched."
+#~ msgstr "В настоящее время синхронизировано."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr "&Пуск"
+#~ msgid "Logout"
+#~ msgstr "Выйти"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Таймер - Стоп"
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "Посетите <a href=\"%1\">%2</a> (открывается в вашем веб-браузере). После "
+#~ "того, как вы войдёте в систему и дадите разрешение на доступ к своему "
+#~ "календарю, он даст вам код для вставки ниже."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 прошло"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Введите код сюда (Например: %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Повтор"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Неверный код Google авторизации"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Таймер-Пауза"
+#~ msgid "Tooltip"
+#~ msgstr "Подсказка"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Таймер-Пуск"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Невозможно отменить локальное время из всплывающей подсказки"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Прокрутите, чтобы добавить время"
+#~ msgid "Set Locale…"
+#~ msgstr "Установить локаль …"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Звук"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Выставить таймер"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Начало событий"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Текущие события"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Ближайшие события"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Прокрутите, чтобы добавить время"
 
 #~ msgid "Weather API limit reached, will try again soon."
 #~ msgstr "Достигнут погодный лимит API, обновится чуть позже."

--- a/package/translate/ru.po
+++ b/package/translate/ru.po
@@ -235,7 +235,7 @@ msgstr "Невозможно установить соединение"
 #: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
 #: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "HTTP Error %1: %2"
-msgstr "Ошибка соединения %1: %2"
+msgstr "Ошибка HTTP %1: %2"
 
 #: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
 #: ../contents/ui/calendars/GoogleTasksManager.qml

--- a/package/translate/sl.po
+++ b/package/translate/sl.po
@@ -176,7 +176,7 @@ msgstr "&Prekliči"
 
 #: ../contents/ui/EditTaskForm.qml
 msgid "Add due date"
-msgstr "Dodaj obdobje trajanja"
+msgstr "Dodaj rok"
 
 #: ../contents/ui/LocaleFuncs.js
 msgctxt "event time on the hour (24 hour clock)"

--- a/package/translate/sl.po
+++ b/package/translate/sl.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2021-07-29 01:08+0200\n"
 "Last-Translator: Ugo Ugowsky <ugowsky@gmail.com>\n"
 "Language-Team: Slovenian <lugos-slo@lugos.si>\n"
@@ -18,18 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100>=3 && "
 "n%100<=4 ? 2 : 3);\n"
 "X-Generator: Poedit 3.0\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Koledar z dnevnim redom"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
-"Vtičnik za koledar z dnevnim redom in vremensko napovedjo, ki se usklajuje z "
-"Googlovim koledarjem."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -52,6 +41,7 @@ msgid "Agenda"
 msgstr "Dnevni red"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Dogodki"
 
@@ -71,10 +61,17 @@ msgstr "Vreme"
 msgid "Advanced"
 msgstr "Napredno"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Ves dan"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -97,6 +94,18 @@ msgid "Edit in browser"
 msgstr "Uredi v brskalniku"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM d"
@@ -106,42 +115,302 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "MMM d"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Koledar z dnevnim redom"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Ni koledarjev]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "do"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Ime dogodka"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Ves dan"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Dodaj lokacijo"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Dodaj opis"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&Shrani"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Prekliči"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Dodaj obdobje trajanja"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr "Ni povezave"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "HTTP napaka %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr "Ponovni poizkus kmalu."
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Dosežena omejitev API-ja za vreme"
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+"Vtičnik je bil posodobljen. Potrebna je ponovna prijava v Googlov koledar."
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Odjavljen/a iz Googla. Potrebna je ponovna prijava."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "MMMM d, yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "npr.: 9.00-17.00 služba"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Vreme ni nastavljeno.\n"
+"V nastavitvah tega vtičnika kliknite na Vreme ter določite svoje mesto,\n"
+"in/ali onemogočite meteogram, da se skrije to območje."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Napaka pri prenosu podatkov o vremenu."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Odštevalnik"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Odštevanje zaključeno"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 je mimo"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Ponovi"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Premor"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Začni z odštevanjem"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Zvok"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Določi ročno"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Dogodki, ki se bodo začeli"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Dogodki, ki potekajo"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Prihajajoči dogodki"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(brez naslova)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Ni koledarjev]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "HTTP napaka %1: %2"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr "Ni povezave"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr "Ponovni poizkus kmalu."
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr ""
-"Vtičnik je bil posodobljen. Potrebna je ponovna prijava v Googlov koledar."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "Preveč spletnih poizvedb. Ponovni poizkus kmalu."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -190,8 +459,8 @@ msgid "Click Weather:"
 msgstr "Klik na vreme:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Odpre vremensko napoved v brskalniku"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -199,12 +468,8 @@ msgid "Click Date:"
 msgstr "Klik na datum:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Odpre nov dogodek v brskalniku"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Odpre okno za vpis dogodka"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -223,8 +488,8 @@ msgid "Click Event:"
 msgstr "Klik na dogodek:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Odpre dogodek v brskalniku"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -304,11 +569,6 @@ msgstr "Slog"
 msgid "Current Month Title:"
 msgstr "Ime trenutnega meseca:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "MMMM d, yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Pokaži obrobe"
@@ -386,6 +646,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Vtičniki za Plasma koledar"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Razno"
@@ -427,10 +693,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Meteogram"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Odštevalnik"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -540,45 +802,230 @@ msgid "Enable Debugging"
 msgstr "Omogoči razhroščevanje"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Prijava"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Trenutno usklajeno."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Odjava"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Za uskladitev z Googlovim koledarjem"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"obiščite <a href=\"%1\">%2</a> (odpre v brskalniku). Po uspešni prijavi in "
-"odobritvi dovoljenj do dostopa, boste prejeli kodo, ki jo prilepite spodaj."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Kopiraj povezavo"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Prilepi kodo sem (npr. %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Potrdi"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Neveljavna Googlova koda za avtorizacijo"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -626,6 +1073,10 @@ msgid "Calendar Label"
 msgstr "Ime koledarja"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Brskaj"
 
@@ -642,12 +1093,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Dnevni red pod koledarjem (en stolpec)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Izbira"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Ni mogoče odstraniti izbire osnovnega kraja"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -655,6 +1140,10 @@ msgstr "Podatki"
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
 msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
@@ -772,39 +1261,41 @@ msgstr "Spletna stran mesta"
 msgid "Open Link"
 msgstr "Odpri povezavo"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "do"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Ime dogodka"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Dodaj lokacijo"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Dodaj opis"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&Shrani"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Prekliči"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Dodaj obdobje trajanja"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -827,151 +1318,70 @@ msgstr "Zvokovne datoteke (%1)"
 msgid "All files (%1)"
 msgstr "Vse datoteke (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Dosežena omejitev API-ja za vreme"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Odjavljen/a iz Googla. Potrebna je ponovna prijava."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Določi jezik …"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Določi državo …"
+#~ msgid ""
+#~ "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr ""
+#~ "Vtičnik za koledar z dnevnim redom in vremensko napovedjo, ki se "
+#~ "usklajuje z Googlovim koledarjem."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr ""
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Odpre vremensko napoved v brskalniku"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr ""
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Odpre nov dogodek v brskalniku"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr ""
+#~ msgid "Open New Event Form"
+#~ msgstr "Odpre okno za vpis dogodka"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "npr.: 9.00-17.00 služba"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Odpre dogodek v brskalniku"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Vreme ni nastavljeno.\n"
-"V nastavitvah tega vtičnika kliknite na Vreme ter določite svoje mesto,\n"
-"in/ali onemogočite meteogram, da se skrije to območje."
+#~ msgid "Login"
+#~ msgstr "Prijava"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Napaka pri prenosu podatkov o vremenu."
+#~ msgid "Currently Synched."
+#~ msgstr "Trenutno usklajeno."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr ""
+#~ msgid "Logout"
+#~ msgstr "Odjava"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Odštevanje zaključeno"
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "obiščite <a href=\"%1\">%2</a> (odpre v brskalniku). Po uspešni prijavi "
+#~ "in odobritvi dovoljenj do dostopa, boste prejeli kodo, ki jo prilepite "
+#~ "spodaj."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 je mimo"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Prilepi kodo sem (npr. %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Ponovi"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Neveljavna Googlova koda za avtorizacijo"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Premor"
+#~ msgid "Tooltip"
+#~ msgstr "Izbira"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Začni z odštevanjem"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Ni mogoče odstraniti izbire osnovnega kraja"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Drsanje  daljša/krajša čas odštevalnika"
+#~ msgid "Set Locale…"
+#~ msgstr "Določi državo …"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Zvok"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Določi ročno"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Dogodki, ki se bodo začeli"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Dogodki, ki potekajo"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Prihajajoči dogodki"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Drsanje  daljša/krajša čas odštevalnika"

--- a/package/translate/sv.po
+++ b/package/translate/sv.po
@@ -15,7 +15,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -151,7 +151,7 @@ msgstr "Titel Händelse"
 
 #: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
 msgid "All Day"
-msgstr "Alla dagar"
+msgstr "Hela dagen"
 
 #: ../contents/ui/EditEventForm.qml
 msgid "Add location"
@@ -358,7 +358,7 @@ msgstr ""
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
-msgstr "(Ingen title)"
+msgstr "(Ingen titel)"
 
 #: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."

--- a/package/translate/sv.po
+++ b/package/translate/sv.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Mathias <EMAIL@ADDRESS>\n"
 "Language-Team: Swedish <LL@li.org>\n"
@@ -16,14 +16,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr ""
-
-#: ../metadata.desktop
-msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr "Plasmoid för kalender och agenda med väder som synkroniseras med Google Kalender."
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -45,7 +37,7 @@ msgstr "Kalender"
 msgid "Agenda"
 msgstr "Dagordning"
 
-#: ../contents/config/config.qml
+#: ../contents/config/config.qml ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Händelser"
 
@@ -65,9 +57,17 @@ msgstr "Väder"
 msgid "Advanced"
 msgstr "Avancerat"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Alla dagar"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -90,6 +90,18 @@ msgid "Edit in browser"
 msgstr "Redigera i Webbläsare"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr ""
@@ -99,9 +111,248 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr ""
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr ""
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Inga Kalendrar]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "till"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Titel Händelse"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Alla dagar"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr "Lägg till plats"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr "Lägg till beskrivning"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "&Spara"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr "Lägg till slutdatum"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1t"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr "Kunde inte ansluta"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr "HTTP-Fel %1: %2"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr "Försöker igen snart."
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr "Väder-API-gräns uppnådd"
+
+#: ../contents/ui/Logic.qml
+msgid "Google authorization expired or was revoked. Open Event Calendar Settings, select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Widget has been updated. Please logout and login to Google Calendar again."
+msgstr "Widgeten har uppdaterats. Logga ut och sedan in från Google Kalender."
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr "Utloggad från Google. Logga in igen."
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "T.ex 9.00-17.00 Arbete"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Väder är inte konfigurerat.\n"
+"Gå till Väder i inställningar och ställ in väder för önskad stad,\n"
+"och/eller inaktivera meteogrammet för att dölja detta område."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr "Det gick inte att hämta väder."
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Stoppur"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Tiden är ute"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 har passerat"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Upprepa"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Pausa Timer"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Starta Timer"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Ljud"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Ställ in Timer"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Händelser startar"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Händelser pågår"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Kommande Händelser"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
 msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
@@ -109,29 +360,41 @@ msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Ingen title)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Inga Kalendrar]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr "HTTP-Fel %1: %2"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr "Kunde inte ansluta"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr "Försöker igen snart."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid "Widget has been updated. Please logout and login to Google Calendar again."
-msgstr "Widgeten har uppdaterats. Logga ut och sedan in från Google Kalender."
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
 msgstr "För många anslutsförfrågningar. Försöker igen snart."
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show agenda"
@@ -178,20 +441,16 @@ msgid "Click Weather:"
 msgstr "Klicka på Väder:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Öppna väderprognos i webbläsare"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml ../contents/ui/config/ConfigCalendar.qml
 msgid "Click Date:"
 msgstr "Klicka på datum:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Öppna ny händelse i webbläsare"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Öppna nytt händelseformulär"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -210,8 +469,8 @@ msgid "Click Event:"
 msgstr "Klicka på händelse:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Öppna händelse i webbläsare"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -289,11 +548,6 @@ msgstr "Stil"
 msgid "Current Month Title:"
 msgstr "Nuvarande månadsrubrik:"
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr ""
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Visa ramar"
@@ -370,6 +624,10 @@ msgstr ""
 msgid "Plasma Calendar Plugins"
 msgstr "Plasma kalender plugins"
 
+#: ../contents/ui/config/ConfigEvents.qml
+msgid "Plasma calendar plugins are unavailable. Install the Plasma calendar module to manage these plugins."
+msgstr ""
+
 #: ../contents/ui/config/ConfigEvents.qml ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Övrigt"
@@ -406,10 +664,6 @@ msgstr "Visa/dölj widgetar ovanför kalendern. Växla Agenda/Kalender på respe
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr ""
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Stoppur"
 
 #: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/lib/ConfigNotification.qml
 msgid "SFX:"
@@ -508,40 +762,200 @@ msgid "Enable Debugging"
 msgstr "Aktivera felsökning"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Logga in"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Synkroniserad."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Logga ut"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google login failed because the browser returned an unexpected state token. Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically. Use the login link below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google access for this account expired or was revoked. Use Update Selected below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Using a previously stored Google OAuth client for compatibility. If login still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The built-in Google OAuth client is currently rejected by Google because it requires a client secret. Provide your own client ID and client secret to enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and secret with the redirect URI set to %1. Leaving these empty only works if a previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "For a custom OAuth client, publish the OAuth consent screen to Production. Google expires refresh tokens for external apps left in Testing after seven days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "För att synkronisera med Google Kalender"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
-msgstr "Besök <a href=\"%1\">%2</a> (öppnas i din webbläsare). När du har loggat in och gett behörighet att komma åt din kalender kommer den att ge dig en kod att klistra in nedan."
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to a localhost URL. If auto-capture succeeds you can ignore the field below; otherwise copy the full URL (or just the code) and paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to the helper page and will try to send the code back automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr "Kopiera länk"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Ange koden här (t.ex. %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "If your browser shows a connection error, that's expected. Copy the URL from the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture fails, copy the code from the helper page and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Skicka in"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Ogiltig Google-auktoriseringskod"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/config/ConfigICal.qml
 msgid "Calendars"
@@ -588,6 +1002,10 @@ msgid "Calendar Label"
 msgstr "Kalenderetikett"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Bläddra"
 
@@ -604,12 +1022,44 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr "Dagordning under kalender (enkel kolumn)"
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Verktygstips"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Det går inte att avmarkera lokal tid från verktygstipset"
+msgid "Enter time zone IDs (for example: Europe/London, America/New_York). The list controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -617,6 +1067,10 @@ msgstr "Data"
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
 msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
@@ -725,38 +1179,41 @@ msgstr "Länk stad"
 msgid "Open Link"
 msgstr "Öppna länk"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "till"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Titel Händelse"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
-msgstr "Lägg till plats"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
-msgstr "Lägg till beskrivning"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "&Spara"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Avbryt"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
-msgstr "Lägg till slutdatum"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
+msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
 msgid "<b>Version:</b> %1"
@@ -779,151 +1236,61 @@ msgstr "Ljudfiler (%1)"
 msgid "All files (%1)"
 msgstr "Alla filer (%1)"
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1t"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr "Väder-API-gräns uppnådd"
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr "Utloggad från Google. Logga in igen."
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Ställ in språk…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Välj språk…"
+#~ msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
+#~ msgstr "Plasmoid för kalender och agenda med väder som synkroniseras med Google Kalender."
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr ""
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Öppna väderprognos i webbläsare"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr ""
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Öppna ny händelse i webbläsare"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr ""
+#~ msgid "Open New Event Form"
+#~ msgstr "Öppna nytt händelseformulär"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "T.ex 9.00-17.00 Arbete"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Öppna händelse i webbläsare"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Väder är inte konfigurerat.\n"
-"Gå till Väder i inställningar och ställ in väder för önskad stad,\n"
-"och/eller inaktivera meteogrammet för att dölja detta område."
+#~ msgid "Login"
+#~ msgstr "Logga in"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr "Det gick inte att hämta väder."
+#~ msgid "Currently Synched."
+#~ msgstr "Synkroniserad."
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr ""
+#~ msgid "Logout"
+#~ msgstr "Logga ut"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Tiden är ute"
+#~ msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
+#~ msgstr "Besök <a href=\"%1\">%2</a> (öppnas i din webbläsare). När du har loggat in och gett behörighet att komma åt din kalender kommer den att ge dig en kod att klistra in nedan."
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 har passerat"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Ange koden här (t.ex. %1)"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Upprepa"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Ogiltig Google-auktoriseringskod"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Pausa Timer"
+#~ msgid "Tooltip"
+#~ msgstr "Verktygstips"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Starta Timer"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Det går inte att avmarkera lokal tid från verktygstipset"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Scrolla för att ändra tidslängd"
+#~ msgid "Set Locale…"
+#~ msgstr "Välj språk…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Ljud"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Ställ in Timer"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Händelser startar"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Händelser pågår"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Kommande Händelser"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Scrolla för att ändra tidslängd"

--- a/package/translate/template.pot
+++ b/package/translate/template.pot
@@ -1,5 +1,5 @@
 # Translation of eventcalendar in LANGUAGE
-# Copyright (C) 2023
+# Copyright (C) 2026
 # This file is distributed under the same license as the eventcalendar package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,14 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr ""
-
-#: ../metadata.desktop
-msgid "Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -46,7 +38,7 @@ msgstr ""
 msgid "Agenda"
 msgstr ""
 
-#: ../contents/config/config.qml
+#: ../contents/config/config.qml ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr ""
 
@@ -66,8 +58,16 @@ msgstr ""
 msgid "Advanced"
 msgstr ""
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
-msgid "All Day"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
 msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
@@ -91,6 +91,18 @@ msgid "Edit in browser"
 msgstr ""
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr ""
@@ -100,9 +112,245 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr ""
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr ""
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr ""
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr ""
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Google authorization expired or was revoked. Open Event Calendar Settings, select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr ""
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr ""
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr ""
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr ""
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr ""
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr ""
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr ""
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
 msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
@@ -110,28 +358,40 @@ msgctxt "event with no summary"
 msgid "(No title)"
 msgstr ""
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Too many web requests. Will try again soon."
 msgstr ""
 
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid "Widget has been updated. Please logout and login to Google Calendar again."
+#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
 msgstr ""
 
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-msgid "Too many web requests. Will try again soon."
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -179,7 +439,7 @@ msgid "Click Weather:"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
+msgid "Currently opens the city forecast in your browser."
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml ../contents/ui/config/ConfigCalendar.qml
@@ -187,11 +447,7 @@ msgid "Click Date:"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr ""
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
+msgid "Currently opens the new event form in the agenda."
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -211,7 +467,7 @@ msgid "Click Event:"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
+msgid "Currently opens the selected event in your browser."
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -290,11 +546,6 @@ msgstr ""
 msgid "Current Month Title:"
 msgstr ""
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr ""
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr ""
@@ -371,6 +622,10 @@ msgstr ""
 msgid "Plasma Calendar Plugins"
 msgstr ""
 
+#: ../contents/ui/config/ConfigEvents.qml
+msgid "Plasma calendar plugins are unavailable. Install the Plasma calendar module to manage these plugins."
+msgstr ""
+
 #: ../contents/ui/config/ConfigEvents.qml ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr ""
@@ -406,10 +661,6 @@ msgstr ""
 
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
-msgstr ""
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/lib/ConfigNotification.qml
@@ -509,15 +760,130 @@ msgid "Enable Debugging"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
+msgid "Google Account"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
+msgid "Google Account %1"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google login failed because the browser returned an unexpected state token. Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically. Use the login link below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google access for this account expired or was revoked. Use Update Selected below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Using a previously stored Google OAuth client for compatibility. If login still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The built-in Google OAuth client is currently rejected by Google because it requires a client secret. Provide your own client ID and client secret to enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and secret with the redirect URI set to %1. Leaving these empty only works if a previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. Google expires refresh tokens for external apps left in Testing after seven days; Workspace session controls can also "
+"require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -525,7 +891,27 @@ msgid "To sync with Google Calendar"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and give permission to access your calendar, it will give you a code to paste below."
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to a localhost URL. If auto-capture succeeds you can ignore the field below; otherwise copy the full "
+"URL (or just the code) and paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, the browser redirects to the helper page and will try to send the code back automatically. If it fails, copy the code and "
+"paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -533,7 +919,39 @@ msgid "Copy Link"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "If your browser shows a connection error, that's expected. Copy the URL from the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture fails, copy the code from the helper page and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -541,7 +959,7 @@ msgid "Submit"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
+msgid "Update Selected"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/config/ConfigICal.qml
@@ -589,6 +1007,10 @@ msgid "Calendar Label"
 msgstr ""
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr ""
 
@@ -605,11 +1027,43 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
+msgid "Local"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
+msgid "Enter time zone IDs (for example: Europe/London, America/New_York). The list controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
 msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
@@ -618,6 +1072,10 @@ msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
 msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
@@ -726,37 +1184,40 @@ msgstr ""
 msgid "Open Link"
 msgstr ""
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
 msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
 msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
@@ -780,148 +1241,16 @@ msgstr ""
 msgid "All files (%1)"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr ""
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
-msgstr ""
-
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr ""
-
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr ""
-
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr ""
-
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr ""
-
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr ""
-
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr ""
-
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr ""
-
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr ""
-
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr ""
-
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr ""
-
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr ""
-
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr ""
-
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr ""
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr ""
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr ""
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr ""
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr ""
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr ""
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
 msgstr ""

--- a/package/translate/tr.po
+++ b/package/translate/tr.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2019-06-02 22:28+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,16 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2.1\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Etkinlik Takvimi"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -49,6 +40,7 @@ msgid "Agenda"
 msgstr "Ajanda"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Etkinlikler"
 
@@ -68,10 +60,17 @@ msgstr "Hava Durumu"
 msgid "Advanced"
 msgstr "Gelişmiş"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Tüm Gün"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -94,6 +93,18 @@ msgid "Edit in browser"
 msgstr "Tarayıcıda düzenle"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM d"
@@ -103,40 +114,300 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
 msgstr "MMM d"
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Etkinlik Takvimi"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Takvim Yok]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "dan"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "Etkinlik Başlığı"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Tüm Gün"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "Kaydet"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "İptal"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "h"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "h:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr "h AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr "h:mm AP"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr "%1, %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr "%1 - %2"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1s"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1dk"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1sn"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr ""
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1mm"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr "MMMM d, yyyy"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr "MMMM"
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr "MMMM, yyyy"
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Örn: 9-5 arası iş"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Hava durumu henüz ayarlanmadı.\n"
+"Ayarlardan Hava Durumu'na girin ve şehrinizi seçin,\n"
+"sonrasında ise burada gözükmesi için meteogramı açın/kapatın."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr ""
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Zamanlayıcı"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Zamanlayıcı tamamlandı"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 geçti"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Tekrarla"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Zamanlayıcıyı Durdur"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Zamanlayıcıyı Başlat"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Ses"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "Zamanlayıcıyı Ayarla"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Etkinlikler Başlıyor"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Devam Eden Etkinlikler"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Gelecek Etkinlikler"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
+msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
 msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Başlık yok)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Takvim Yok]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr ""
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -186,8 +457,8 @@ msgid "Click Weather:"
 msgstr "Hava Durumuna Tıklama:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Güncel Durumu Tarayıcıda Aç"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -195,12 +466,8 @@ msgid "Click Date:"
 msgstr "Tarihe Tıklama:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Tarayıcıda Yeni Etkinlik Oluşturmayı Aç"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Yeni Etkinlik Formunu Aç"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -219,8 +486,8 @@ msgid "Click Event:"
 msgstr "Etkinliğe Tıklama:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Etkinliği Tarayıcıda Aç"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -300,11 +567,6 @@ msgstr "Tarz"
 msgid "Current Month Title:"
 msgstr ""
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr "MMMM d, yyyy"
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Kenarıkları Göster"
@@ -382,6 +644,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Plasma Takvimi Eklentileri"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Ekstra"
@@ -423,10 +691,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Meteogram"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Zamanlayıcı"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -537,46 +801,230 @@ msgid "Enable Debugging"
 msgstr "Debug'ı Etkinleştir"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Giriş Yap"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "Senkronize Edili."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Çıkış Yap"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Google Calendar ile senkronizeleşmek için"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"Tarayıcınızdan <a href=\"%1\">%2</a> adresini ziyaret edin. Giriş yaptıktan "
-"ve gerekli izinleri verdikten sonra size verilen kodu aşağıdaki alana "
-"yapıştırın."
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "Kodu buraya girin (Örn: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "Gönder"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "Geçersiz Google Doğrulama Kodu"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -624,6 +1072,10 @@ msgid "Calendar Label"
 msgstr "Takvim Etiketi"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Tara"
 
@@ -640,12 +1092,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "İpuçları"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Yerel zaman ipuçlarından seçim dışı edilemez"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -654,6 +1140,10 @@ msgstr "Veri"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "API Uygulama ID'si:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -768,38 +1258,40 @@ msgstr "Şehir Sayfası"
 msgid "Open Link"
 msgstr "Linki Aç"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "dan"
-
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "Etkinlik Başlığı"
-
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "Kaydet"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "İptal"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
 msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
@@ -823,154 +1315,67 @@ msgstr ""
 msgid "All files (%1)"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "h"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "h:mm"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr "h AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr "h:mm AP"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr "%1, %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr "%1 - %2"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1s"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1dk"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1sn"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "Dili Ayarla…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Bölgeyi Ayarla…"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Güncel Durumu Tarayıcıda Aç"
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1mm"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Tarayıcıda Yeni Etkinlik Oluşturmayı Aç"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr "MMMM"
+#~ msgid "Open New Event Form"
+#~ msgstr "Yeni Etkinlik Formunu Aç"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr "MMMM, yyyy"
+#~ msgid "Open Event In Browser"
+#~ msgstr "Etkinliği Tarayıcıda Aç"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Örn: 9-5 arası iş"
+#~ msgid "Login"
+#~ msgstr "Giriş Yap"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Hava durumu henüz ayarlanmadı.\n"
-"Ayarlardan Hava Durumu'na girin ve şehrinizi seçin,\n"
-"sonrasında ise burada gözükmesi için meteogramı açın/kapatın."
+#~ msgid "Currently Synched."
+#~ msgstr "Senkronize Edili."
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr ""
+#~ msgid "Logout"
+#~ msgstr "Çıkış Yap"
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr ""
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "Tarayıcınızdan <a href=\"%1\">%2</a> adresini ziyaret edin. Giriş "
+#~ "yaptıktan ve gerekli izinleri verdikten sonra size verilen kodu aşağıdaki "
+#~ "alana yapıştırın."
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Zamanlayıcı tamamlandı"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "Kodu buraya girin (Örn: %1)"
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 geçti"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "Geçersiz Google Doğrulama Kodu"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Tekrarla"
+#~ msgid "Tooltip"
+#~ msgstr "İpuçları"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Zamanlayıcıyı Durdur"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Yerel zaman ipuçlarından seçim dışı edilemez"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Zamanlayıcıyı Başlat"
+#~ msgid "Set Locale…"
+#~ msgstr "Bölgeyi Ayarla…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Süre eklemek için kaydırın"
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Ses"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "Zamanlayıcıyı Ayarla"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Etkinlikler Başlıyor"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Devam Eden Etkinlikler"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Gelecek Etkinlikler"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Süre eklemek için kaydırın"
 
 #~ msgid ""
 #~ "Enable Debugging\n"

--- a/package/translate/uk.po
+++ b/package/translate/uk.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2017-10-31 20:08+0200\n"
 "Last-Translator: Serhii Golovko <cappelikan@gmail.com>\n"
 "Language-Team: \n"
@@ -18,16 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 1.8.7.1\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr "Календар подій"
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -50,6 +41,7 @@ msgid "Agenda"
 msgstr "Порядок денний"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "Події"
 
@@ -69,10 +61,17 @@ msgstr "Погода"
 msgid "Advanced"
 msgstr "Розширений"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "Весь день"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -95,6 +94,18 @@ msgid "Edit in browser"
 msgstr "Редагувати в браузері"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr "MMM d"
@@ -104,9 +115,257 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr "ddd"
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr "Календар подій"
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[Без календарів]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "до"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "Весь день"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "Зберегти"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "&Скасувати"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr "%1ч"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr "%1м"
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr "%1с"
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr ""
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr "%1мм"
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "Наприклад: 9: 00-17: 00 Робота"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"Погода не налаштована.\n"
+"Перейдіть до погоди в налаштуваннях і встановіть своє місто,\n"
+"і / або вимкнути метеограму, щоб приховати цю область."
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr ""
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "Таймер"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "Таймер закінчився"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1 пройшло"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "Повторити"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "Призупинити таймер"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "Запустити таймер"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "Звук"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr ""
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "Початок подій"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "Події в процесі"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "Майбутні події"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
 msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
@@ -114,30 +373,42 @@ msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "(Без назви)"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[Без календарів]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr ""
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -187,8 +458,8 @@ msgid "Click Weather:"
 msgstr "Натисніть \"Погода\":"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "Відкрийте прогноз міста в браузері"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -196,12 +467,8 @@ msgid "Click Date:"
 msgstr "Натисніть Дата:"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "Відкрийте нову подію в браузері"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "Відкрийте форму нової події"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -220,8 +487,8 @@ msgid "Click Event:"
 msgstr "Натисніть \"Подія\":"
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "Відкрита подія в браузері"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -301,11 +568,6 @@ msgstr "Стиль"
 msgid "Current Month Title:"
 msgstr ""
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr ""
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "Показати кордони"
@@ -383,6 +645,12 @@ msgid "Plasma Calendar Plugins"
 msgstr ""
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "Різне"
@@ -424,10 +692,6 @@ msgstr ""
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "Метеограма"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "Таймер"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -537,26 +801,176 @@ msgid "Enable Debugging"
 msgstr "Увімкнути налагодження"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "Увійти"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "В даний час синхронізовано."
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "Вийти"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "Синхронізувати з Календарем Google"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto) - Add Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -564,7 +978,44 @@ msgid "Copy Link"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -572,7 +1023,7 @@ msgid "Submit"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
+msgid "Update Selected"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
@@ -621,6 +1072,10 @@ msgid "Calendar Label"
 msgstr "Мітка календаря"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "Перегляд"
 
@@ -637,12 +1092,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "Підказка"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "Неможливо скасувати вибір місцевого часу з підказки"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -651,6 +1140,10 @@ msgstr "Дані"
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
 msgstr "Ідентифікатор додатка API:"
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "City Id:"
@@ -766,38 +1259,40 @@ msgstr "Міська веб-сторінка"
 msgid "Open Link"
 msgstr "Відкрити посилання"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "до"
-
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "Зберегти"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "&Скасувати"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
 msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
@@ -821,154 +1316,52 @@ msgstr ""
 msgid "All files (%1)"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr "%1ч"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr "%1м"
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr "%1с"
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr ""
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr ""
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "Встановити мову …"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "Відкрийте прогноз міста в браузері"
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr "%1мм"
+#~ msgid "Open New Event In Browser"
+#~ msgstr "Відкрийте нову подію в браузері"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr ""
+#~ msgid "Open New Event Form"
+#~ msgstr "Відкрийте форму нової події"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr ""
+#~ msgid "Open Event In Browser"
+#~ msgstr "Відкрита подія в браузері"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "Наприклад: 9: 00-17: 00 Робота"
+#~ msgid "Login"
+#~ msgstr "Увійти"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"Погода не налаштована.\n"
-"Перейдіть до погоди в налаштуваннях і встановіть своє місто,\n"
-"і / або вимкнути метеограму, щоб приховати цю область."
+#~ msgid "Currently Synched."
+#~ msgstr "В даний час синхронізовано."
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr ""
+#~ msgid "Logout"
+#~ msgstr "Вийти"
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr ""
+#~ msgid "Tooltip"
+#~ msgstr "Підказка"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "Таймер закінчився"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "Неможливо скасувати вибір місцевого часу з підказки"
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1 пройшло"
+#~ msgid "Set Locale…"
+#~ msgstr "Встановити мову …"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "Повторити"
-
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "Призупинити таймер"
-
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "Запустити таймер"
-
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "Прокрутіть, щоб додати тривалість"
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "Звук"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr ""
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "Початок подій"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "Події в процесі"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "Майбутні події"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "Прокрутіть, щоб додати тривалість"
 
 #~ msgid "Choose"
 #~ msgstr "Виберіть"
@@ -992,8 +1385,8 @@ msgstr ""
 #~ "Enter the following code at <a href=\"https://www.google.com/"
 #~ "device\">https://www.google.com/device</a>."
 #~ msgstr ""
-#~ "Введіть цей код на <a href=\"https://www.google.com/device\">https://www."
-#~ "google.com/device</a>."
+#~ "Введіть цей код на <a href=\"https://www.google.com/device\">https://"
+#~ "www.google.com/device</a>."
 
 #~ msgid "Generating Code…"
 #~ msgstr "Генерації коду …"

--- a/package/translate/zh_CN.po
+++ b/package/translate/zh_CN.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eventcalendar\n"
-"Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-eventcalendar\n"
-"POT-Creation-Date: 2023-08-18 10:16-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ALikesToCode/plasma-applet-"
+"eventcalendar\n"
+"POT-Creation-Date: 2026-07-18 14:17+0530\n"
 "PO-Revision-Date: 2019-04-17 16:43+0800\n"
 "Last-Translator: Core小睿 <i@coreja.com>\n"
 "Language-Team: \n"
@@ -17,16 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.2.1\n"
-
-#: ../metadata.desktop ../contents/ui/AgendaView.qml
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Event Calendar"
-msgstr ""
-
-#: ../metadata.desktop
-msgid ""
-"Plasmoid for a calendar+agenda with weather that syncs to Google Calendar."
-msgstr ""
 
 #: ../contents/config/config.qml
 msgid "General"
@@ -49,6 +40,7 @@ msgid "Agenda"
 msgstr "日程"
 
 #: ../contents/config/config.qml
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
 msgid "Events"
 msgstr "事件"
 
@@ -68,10 +60,17 @@ msgstr "天气"
 msgid "Advanced"
 msgstr "高级"
 
-#: ../contents/ui/AgendaEventItem.qml ../contents/ui/EditEventForm.qml
-#: ../contents/ui/LocaleFuncs.js
-msgid "All Day"
-msgstr "全天"
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Calendar event"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "In progress"
+msgstr ""
+
+#: ../contents/ui/AgendaEventItem.qml
+msgid "Press to open the event in the browser"
+msgstr ""
 
 #: ../contents/ui/AgendaEventItem.qml
 msgid "Hangout"
@@ -94,6 +93,18 @@ msgid "Edit in browser"
 msgstr "在浏览器中编辑"
 
 #: ../contents/ui/AgendaListItem.qml
+msgid "Weather forecast for %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to add a new event on %1"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
+msgid "Press to open the weather forecast in your browser"
+msgstr ""
+
+#: ../contents/ui/AgendaListItem.qml
 msgctxt "agenda date format line 1"
 msgid "MMM d"
 msgstr ""
@@ -103,9 +114,257 @@ msgctxt "agenda date format line 2"
 msgid "ddd"
 msgstr ""
 
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Due %1"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Overdue"
+msgstr ""
+
 #: ../contents/ui/AgendaTaskItem.qml ../contents/ui/LocaleFuncs.js
 msgctxt "short month+date format"
 msgid "MMM d"
+msgstr ""
+
+#: ../contents/ui/AgendaTaskItem.qml
+msgid "Task"
+msgstr ""
+
+#: ../contents/ui/AgendaView.qml ../contents/ui/UpcomingEvents.qml
+msgid "Event Calendar"
+msgstr ""
+
+#: ../contents/ui/CalendarSelector.qml
+msgid "[No Calendars]"
+msgstr "[没有日历]"
+
+#: ../contents/ui/DateTimeSelector.qml
+msgctxt "event editor date format"
+msgid "d MMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/DurationSelector.qml
+msgid "to"
+msgstr "至"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Event Title"
+msgstr "事件标题"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/LocaleFuncs.js
+msgid "All Day"
+msgstr "全天"
+
+#: ../contents/ui/EditEventForm.qml
+msgid "Add location"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "Add description"
+msgstr ""
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+msgid "&Save"
+msgstr "保存"
+
+#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
+#: ../contents/ui/TimerInputView.qml
+msgid "&Cancel"
+msgstr "取消"
+
+#: ../contents/ui/EditTaskForm.qml
+msgid "Add due date"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (24 hour clock)"
+msgid "h"
+msgstr "hh:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (24 hour clock)"
+msgid "h:mm"
+msgstr "hh:mm"
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time on the hour (12 hour clock)"
+msgid "h AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "event time (12 hour clock)"
+msgid "h:mm AP"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "date (%1) with time (%2)"
+msgid "%1, %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "from date/time %1 until date/time %2"
+msgid "%1 - %2"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+msgctxt "short form for %1 hours"
+msgid "%1h"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 minutes"
+msgid "%1m"
+msgstr ""
+
+#: ../contents/ui/LocaleFuncs.js
+#, c-format
+msgctxt "short form for %1 seconds"
+msgid "%1s"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Could not connect"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "HTTP Error %1: %2"
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Will try again soon."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Weather API limit reached"
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid ""
+"Google authorization expired or was revoked. Open Event Calendar Settings, "
+"select the account, and use Update Selected to reconnect it."
+msgstr ""
+
+#: ../contents/ui/Logic.qml ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Widget has been updated. Please logout and login to Google Calendar again."
+msgstr ""
+
+#: ../contents/ui/Logic.qml
+msgid "Logged out of Google. Please login again."
+msgstr ""
+
+#: ../contents/ui/MeteogramView.qml
+#, c-format
+msgid "%1mm"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml ../contents/ui/config/ConfigCalendar.qml
+msgctxt "calendar title format for current month"
+msgid "MMMM d, yyyy"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for other months of current year"
+msgid "MMMM"
+msgstr ""
+
+#: ../contents/ui/MonthView.qml
+msgctxt "calendar title format for months not from current year"
+msgid "MMMM, yyyy"
+msgstr ""
+
+#: ../contents/ui/NewEventForm.qml
+msgid "Eg: 9am-5pm Work"
+msgstr "例如：9am-5pm 工作"
+
+#: ../contents/ui/PopupView.qml
+msgid ""
+"Weather not configured.\n"
+"Go to Weather in the config and set your city,\n"
+"and/or disable the meteogram to hide this area."
+msgstr ""
+"天气没有配置。\n"
+"请在天气配置中设置你的城市，\n"
+"或者选择是否显示天气预报。"
+
+#: ../contents/ui/PopupView.qml
+msgid "Error fetching weather."
+msgstr ""
+
+#: ../contents/ui/TimerInputView.qml
+msgid "&Start"
+msgstr ""
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/config/ConfigGeneral.qml
+msgid "Timer"
+msgstr "倒计时器"
+
+#: ../contents/ui/TimerModel.qml
+msgid "Timer finished"
+msgstr "倒计时结束"
+
+#: ../contents/ui/TimerModel.qml
+msgid "%1 has passed"
+msgstr "%1过去了"
+
+#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
+msgid "Repeat"
+msgstr "重复"
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to pause."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer, %1 remaining. Activate to start."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Timer set to %1. Use plus or minus to change the duration."
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Pause Timer"
+msgstr "暂停倒计时"
+
+#: ../contents/ui/TimerView.qml
+msgid "Start Timer"
+msgstr "开始倒计时"
+
+#: ../contents/ui/TimerView.qml
+msgid "Scroll or use plus and minus keys to adjust duration"
+msgstr ""
+
+#: ../contents/ui/TimerView.qml
+msgid "Sound"
+msgstr "声音"
+
+#: ../contents/ui/TimerView.qml
+msgid "Set Timer"
+msgstr "设置倒计时"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events Starting"
+msgstr "事件开始"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Events In Progress"
+msgstr "正在进行的事件"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgid "Upcoming Events"
+msgstr "即将到来的事件"
+
+#: ../contents/ui/UpcomingEvents.qml
+msgctxt "%1 = 15 minutes"
+msgid "Starting in %1"
 msgstr ""
 
 #: ../contents/ui/calendars/CalendarManager.qml
@@ -113,30 +372,42 @@ msgctxt "event with no summary"
 msgid "(No title)"
 msgstr "（没有标题）"
 
-#: ../contents/ui/CalendarSelector.qml
-msgid "[No Calendars]"
-msgstr "[没有日历]"
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "HTTP Error %1: %2"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Could not connect"
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml ../contents/ui/Logic.qml
-msgid "Will try again soon."
-msgstr ""
-
 #: ../contents/ui/calendars/GoogleCalendarManager.qml
-#: ../contents/ui/config/ConfigGoogleCalendar.qml ../contents/ui/Logic.qml
-msgid ""
-"Widget has been updated. Please logout and login to Google Calendar again."
-msgstr ""
-
-#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
 msgid "Too many web requests. Will try again soon."
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+#: ../contents/ui/calendars/GoogleTasksManager.qml
+msgid "Google authentication failed: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/GoogleCalendarManager.qml
+msgid "Error fetching calendar: %1"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "iCalendar"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Unknown iCalendar helper error"
+msgstr ""
+
+#: ../contents/ui/calendars/ICalManager.qml
+msgid "Could not load %1: %2"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Holidays"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Todo"
+msgstr ""
+
+#: ../contents/ui/calendars/PlasmaCalendarManager.qml
+msgid "Other"
 msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
@@ -186,8 +457,8 @@ msgid "Click Weather:"
 msgstr "点击天气："
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open City Forecast In Browser"
-msgstr "在浏览器中打开城市天气预报"
+msgid "Currently opens the city forecast in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 #: ../contents/ui/config/ConfigCalendar.qml
@@ -195,12 +466,8 @@ msgid "Click Date:"
 msgstr "点击日期："
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event In Browser"
-msgstr "在浏览器中新建事件"
-
-#: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open New Event Form"
-msgstr "在窗体中新建事件"
+msgid "Currently opens the new event form in the agenda."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Event description"
@@ -219,8 +486,8 @@ msgid "Click Event:"
 msgstr "点击事件："
 
 #: ../contents/ui/config/ConfigAgenda.qml
-msgid "Open Event In Browser"
-msgstr "在浏览器中打开事件"
+msgid "Currently opens the selected event in your browser."
+msgstr ""
 
 #: ../contents/ui/config/ConfigAgenda.qml
 msgid "Show multi-day events:"
@@ -300,11 +567,6 @@ msgstr "样式"
 msgid "Current Month Title:"
 msgstr ""
 
-#: ../contents/ui/config/ConfigCalendar.qml ../contents/ui/MonthView.qml
-msgctxt "calendar title format for current month"
-msgid "MMMM d, yyyy"
-msgstr ""
-
 #: ../contents/ui/config/ConfigCalendar.qml
 msgid "Show Borders"
 msgstr "显示边框"
@@ -382,6 +644,12 @@ msgid "Plasma Calendar Plugins"
 msgstr "Plasma 日历插件"
 
 #: ../contents/ui/config/ConfigEvents.qml
+msgid ""
+"Plasma calendar plugins are unavailable. Install the Plasma calendar module "
+"to manage these plugins."
+msgstr ""
+
+#: ../contents/ui/config/ConfigEvents.qml
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Misc"
 msgstr "杂项"
@@ -421,10 +689,6 @@ msgstr "请在分别在日程/日历的页面上显示/隐藏小部件。"
 #: ../contents/ui/config/ConfigGeneral.qml
 msgid "Meteogram"
 msgstr "天气预报图"
-
-#: ../contents/ui/config/ConfigGeneral.qml ../contents/ui/TimerModel.qml
-msgid "Timer"
-msgstr "倒计时器"
 
 #: ../contents/ui/config/ConfigGeneral.qml
 #: ../contents/ui/lib/ConfigNotification.qml
@@ -533,45 +797,230 @@ msgid "Enable Debugging"
 msgstr "开启Debugging"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Login"
-msgstr "登录"
+msgid "Google Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Currently Synched."
-msgstr "当前已同步。"
+msgid "Google Account %1"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Logout"
-msgstr "注销"
+msgid "Login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login complete."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Could not prepare Google login: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for browser callback..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Waiting for the helper page to send the code..."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google login failed because the browser returned an unexpected state token. "
+"Please retry the login."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed. See logs for details."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: no token data received."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: invalid callback data."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Auto login failed: authorization code missing."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The desktop could not open the browser automatically. Use the login link "
+"below instead."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Accounts"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Account"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Remove"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Currently Synced: %1"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Google access for this account expired or was revoked. Use Update Selected "
+"below to reconnect it without removing the account."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Credentials"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Using a previously stored Google OAuth client for compatibility. If login "
+"still fails, add your own client ID and client secret."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"The built-in Google OAuth client is currently rejected by Google because it "
+"requires a client secret. Provide your own client ID and client secret to "
+"enable Google sync."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Provide a Google Cloud OAuth Desktop client ID, or a Web client ID and "
+"secret with the redirect URI set to %1. Leaving these empty only works if a "
+"previously stored secret-based client is available."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"For a custom OAuth client, publish the OAuth consent screen to Production. "
+"Google expires refresh tokens for external apps left in Testing after seven "
+"days; Workspace session controls can also require reauthorization."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Try desktop built-in client (no secret)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Optional"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Client Secret"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Redirect Mode"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Callback: Localhost (auto capture). Helper page is shown below as a backup."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add another Google account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "To sync with Google Calendar"
 msgstr "用以与Google日历同步"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid ""
-"Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login and "
-"give permission to access your calendar, it will give you a code to paste "
-"below."
+msgid "Login (Auto) - Add Account"
 msgstr ""
-"访问 <a href=\"%1\">%2</a> （会在浏览器中打开）。在你登录并授权访问你的日历"
-"后，请在下方粘贴网页提供的授权码。"
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Login (Auto)"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to a localhost URL. If auto-capture succeeds you can "
+"ignore the field below; otherwise copy the full URL (or just the code) and "
+"paste it."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Click Login (Auto) to open <a href=\"%1\">%2</a>. After you grant access, "
+"the browser redirects to the helper page and will try to send the code back "
+"automatically. If it fails, copy the code and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "The desktop could not open the browser automatically."
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Copy Link"
 msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Enter code here (Eg: %1)"
-msgstr "请在此输入授权码 （例如： %1）"
+msgid "Helper page (optional): <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Helper page: <a href=\"%1\">%1</a>"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"If your browser shows a connection error, that's expected. Copy the URL from "
+"the address bar anyway and paste it below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Tip: If auto-capture works, you do not need to paste anything."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Tip: If auto-capture fails, copy the code from the helper page and paste it "
+"below."
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Paste the authorization code or redirect URL here"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Google authorization code or redirect URL"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid ""
+"Paste the Google authorization code or the full redirect URL from the browser"
+msgstr ""
+
+#: ../contents/ui/config/ConfigGoogleCalendar.qml
+msgid "Add Account"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 msgid "Submit"
 msgstr "提交"
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
-msgid "Invalid Google Authorization Code"
-msgstr "无效的Google授权码"
+msgid "Update Selected"
+msgstr ""
 
 #: ../contents/ui/config/ConfigGoogleCalendar.qml
 #: ../contents/ui/config/ConfigICal.qml
@@ -619,6 +1068,10 @@ msgid "Calendar Label"
 msgstr "日历标签"
 
 #: ../contents/ui/config/ConfigICal.qml
+msgid "https:// URL or local %1/*.ics file"
+msgstr ""
+
+#: ../contents/ui/config/ConfigICal.qml
 msgid "Browse"
 msgstr "浏览"
 
@@ -635,12 +1088,46 @@ msgid "Agenda below the Calendar (Single Column)"
 msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Tooltip"
-msgstr "选择"
+msgid "Local"
+msgstr ""
 
 #: ../contents/ui/config/ConfigTimezones.qml
-msgid "Cannot deselect Local time from the tooltip"
-msgstr "本地时间为必选项"
+msgid ""
+"Enter time zone IDs (for example: Europe/London, America/New_York). The list "
+"controls which zones appear in the tooltip."
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone ID"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Add"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zones"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Identifier"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Remove time zone"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Display time zone as:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone city"
+msgstr ""
+
+#: ../contents/ui/config/ConfigTimezones.qml
+msgid "Time zone code"
+msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "Data"
@@ -648,6 +1135,10 @@ msgstr "数据"
 
 #: ../contents/ui/config/ConfigWeather.qml
 msgid "API App Id:"
+msgstr ""
+
+#: ../contents/ui/config/ConfigWeather.qml
+msgid "Required for OpenWeatherMap"
 msgstr ""
 
 #: ../contents/ui/config/ConfigWeather.qml
@@ -762,38 +1253,40 @@ msgstr "城市网页"
 msgid "Open Link"
 msgstr "打开链接"
 
-#: ../contents/ui/DateTimeSelector.qml
-msgctxt "event editor date format"
-msgid "d MMM, yyyy"
+#: ../contents/ui/configGeneral.qml
+msgid "Appearance:"
 msgstr ""
 
-#: ../contents/ui/DurationSelector.qml
-msgid "to"
-msgstr "至"
-
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Event Title"
-msgstr "事件标题"
-
-#: ../contents/ui/EditEventForm.qml
-msgid "Add location"
+#: ../contents/ui/configGeneral.qml
+msgid "Show animation"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "Add description"
+#: ../contents/ui/configGeneral.qml
+msgid "Counter color:"
 msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-msgid "&Save"
-msgstr "保存"
+#: ../contents/ui/configGeneral.qml
+msgid "Theme color"
+msgstr ""
 
-#: ../contents/ui/EditEventForm.qml ../contents/ui/EditTaskForm.qml
-#: ../contents/ui/TimerInputView.qml
-msgid "&Cancel"
-msgstr "取消"
+#: ../contents/ui/configGeneral.qml
+msgid "Red"
+msgstr ""
 
-#: ../contents/ui/EditTaskForm.qml
-msgid "Add due date"
+#: ../contents/ui/configGeneral.qml
+msgid "Green"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Blue"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Increment step:"
+msgstr ""
+
+#: ../contents/ui/configGeneral.qml
+msgid "Maximum value:"
 msgstr ""
 
 #: ../contents/ui/lib/AppletVersion.qml
@@ -817,154 +1310,66 @@ msgstr ""
 msgid "All files (%1)"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (24 hour clock)"
-msgid "h"
-msgstr "hh:mm"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (24 hour clock)"
-msgid "h:mm"
-msgstr "hh:mm"
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time on the hour (12 hour clock)"
-msgid "h AP"
+#: ../contents/ui/main.qml
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "event time (12 hour clock)"
-msgid "h:mm AP"
+#: ../contents/ui/main.qml
+msgid "Refresh Events"
 msgstr ""
 
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "date (%1) with time (%2)"
-msgid "%1, %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "from date/time %1 until date/time %2"
-msgid "%1 - %2"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-msgctxt "short form for %1 hours"
-msgid "%1h"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 minutes"
-msgid "%1m"
-msgstr ""
-
-#: ../contents/ui/LocaleFuncs.js
-#, c-format
-msgctxt "short form for %1 seconds"
-msgid "%1s"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Weather API limit reached"
-msgstr ""
-
-#: ../contents/ui/Logic.qml
-msgid "Logged out of Google. Please login again."
-msgstr ""
-
+#. i18nd("plasma_applet_org.kde.plasma.digitalclock", "Set Time Format…")
+#. icon.name: "gnumeric-format-thousand-separator"
 #: ../contents/ui/main.qml
 msgid "Set Language…"
 msgstr "设置语言…"
 
-#: ../contents/ui/main.qml
-msgid "Set Locale…"
-msgstr "设置本地化…"
+#~ msgid "Open City Forecast In Browser"
+#~ msgstr "在浏览器中打开城市天气预报"
 
-#: ../contents/ui/MeteogramView.qml
-#, c-format
-msgid "%1mm"
-msgstr ""
+#~ msgid "Open New Event In Browser"
+#~ msgstr "在浏览器中新建事件"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for other months of current year"
-msgid "MMMM"
-msgstr ""
+#~ msgid "Open New Event Form"
+#~ msgstr "在窗体中新建事件"
 
-#: ../contents/ui/MonthView.qml
-msgctxt "calendar title format for months not from current year"
-msgid "MMMM, yyyy"
-msgstr ""
+#~ msgid "Open Event In Browser"
+#~ msgstr "在浏览器中打开事件"
 
-#: ../contents/ui/NewEventForm.qml
-msgid "Eg: 9am-5pm Work"
-msgstr "例如：9am-5pm 工作"
+#~ msgid "Login"
+#~ msgstr "登录"
 
-#: ../contents/ui/PopupView.qml
-msgid ""
-"Weather not configured.\n"
-"Go to Weather in the config and set your city,\n"
-"and/or disable the meteogram to hide this area."
-msgstr ""
-"天气没有配置。\n"
-"请在天气配置中设置你的城市，\n"
-"或者选择是否显示天气预报。"
+#~ msgid "Currently Synched."
+#~ msgstr "当前已同步。"
 
-#: ../contents/ui/PopupView.qml
-msgid "Error fetching weather."
-msgstr ""
+#~ msgid "Logout"
+#~ msgstr "注销"
 
-#: ../contents/ui/TimerInputView.qml
-msgid "&Start"
-msgstr ""
+#~ msgid ""
+#~ "Visit <a href=\"%1\">%2</a> (opens in your web browser). After you login "
+#~ "and give permission to access your calendar, it will give you a code to "
+#~ "paste below."
+#~ msgstr ""
+#~ "访问 <a href=\"%1\">%2</a> （会在浏览器中打开）。在你登录并授权访问你的日"
+#~ "历后，请在下方粘贴网页提供的授权码。"
 
-#: ../contents/ui/TimerModel.qml
-msgid "Timer finished"
-msgstr "倒计时结束"
+#~ msgid "Enter code here (Eg: %1)"
+#~ msgstr "请在此输入授权码 （例如： %1）"
 
-#: ../contents/ui/TimerModel.qml
-msgid "%1 has passed"
-msgstr "%1过去了"
+#~ msgid "Invalid Google Authorization Code"
+#~ msgstr "无效的Google授权码"
 
-#: ../contents/ui/TimerModel.qml ../contents/ui/TimerView.qml
-msgid "Repeat"
-msgstr "重复"
+#~ msgid "Tooltip"
+#~ msgstr "选择"
 
-#: ../contents/ui/TimerView.qml
-msgid "Pause Timer"
-msgstr "暂停倒计时"
+#~ msgid "Cannot deselect Local time from the tooltip"
+#~ msgstr "本地时间为必选项"
 
-#: ../contents/ui/TimerView.qml
-msgid "Start Timer"
-msgstr "开始倒计时"
+#~ msgid "Set Locale…"
+#~ msgstr "设置本地化…"
 
-#: ../contents/ui/TimerView.qml
-msgid "Scroll to add to duration"
-msgstr "滑动滚轮调整时间"
-
-#: ../contents/ui/TimerView.qml
-msgid "Sound"
-msgstr "声音"
-
-#: ../contents/ui/TimerView.qml
-msgid "Set Timer"
-msgstr "设置倒计时"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events Starting"
-msgstr "事件开始"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Events In Progress"
-msgstr "正在进行的事件"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgid "Upcoming Events"
-msgstr "即将到来的事件"
-
-#: ../contents/ui/UpcomingEvents.qml
-msgctxt "%1 = 15 minutes"
-msgid "Starting in %1"
-msgstr ""
+#~ msgid "Scroll to add to duration"
+#~ msgstr "滑动滚轮调整时间"
 
 #~ msgid ""
 #~ "Enable Debugging\n"

--- a/tests/build_shell_runtime.test.js
+++ b/tests/build_shell_runtime.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+
+function read(relativePath) {
+	return fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf8')
+}
+
+const rootBuild = read('build')
+
+assert.ok(
+	rootBuild.includes('(cd package/translate && bash ./merge)')
+		&& rootBuild.includes('(cd package/translate && bash ./build)'),
+	'the packaging workflow must invoke Bash-only translation helpers with Bash'
+)
+
+for (const helper of ['package/translate/build', 'package/translate/merge']) {
+	const source = read(helper)
+	assert.ok(source.startsWith('#!/usr/bin/env bash\n'), `${helper} must declare Bash`)
+	assert.ok(
+		source.includes('exec /usr/bin/env bash "$0" "$@"'),
+		`${helper} must recover when a user invokes it through sh`
+	)
+}
+
+console.log('PASS build_shell_runtime')

--- a/tests/build_shell_runtime.test.js
+++ b/tests/build_shell_runtime.test.js
@@ -17,6 +17,10 @@ assert.ok(
 	rootBuild.includes('python3 -m zipfile -c "$filename" ./*'),
 	'packaging must fall back to Python when the external zip command is unavailable'
 )
+assert.ok(
+	rootBuild.includes('if ! (cd package/translate && bash ./build); then'),
+	'translation compilation failures must stop packaging'
+)
 
 for (const helper of ['package/translate/build', 'package/translate/merge']) {
 	const source = read(helper)
@@ -26,5 +30,16 @@ for (const helper of ['package/translate/build', 'package/translate/merge']) {
 		`${helper} must recover when a user invokes it through sh`
 	)
 }
+
+const translationBuild = read('package/translate/build')
+assert.ok(
+	translationBuild.includes('set -euo pipefail'),
+	'translation compilation must fail on command errors'
+)
+assert.ok(
+	translationBuild.indexOf('mkdir -p "$(dirname "$installPath")"')
+		< translationBuild.indexOf('installPath=$(realpath -- "$installPath")'),
+	'translation destination directories must exist before canonicalization'
+)
 
 console.log('PASS build_shell_runtime')

--- a/tests/build_shell_runtime.test.js
+++ b/tests/build_shell_runtime.test.js
@@ -18,6 +18,10 @@ assert.ok(
 	'packaging must fall back to Python when the external zip command is unavailable'
 )
 assert.ok(
+	rootBuild.includes('command -v zip > /dev/null 2>&1'),
+	'the optional zip probe must not emit an expected command-not-found error'
+)
+assert.ok(
 	rootBuild.includes('if ! (cd package/translate && bash ./build); then'),
 	'translation compilation failures must stop packaging'
 )
@@ -40,6 +44,12 @@ assert.ok(
 	translationBuild.indexOf('mkdir -p "$(dirname "$installPath")"')
 		< translationBuild.indexOf('installPath=$(realpath -- "$installPath")'),
 	'translation destination directories must exist before canonicalization'
+)
+
+const translationMerge = read('package/translate/merge')
+assert.ok(
+	translationMerge.includes("grep -Eq '(i18n|ki18n|xi18n|I18N_NOOP|tr2i18n|tr2xi18n|N_)"),
+	'translation extraction must skip source files without translation calls'
 )
 
 console.log('PASS build_shell_runtime')

--- a/tests/build_shell_runtime.test.js
+++ b/tests/build_shell_runtime.test.js
@@ -13,6 +13,10 @@ assert.ok(
 		&& rootBuild.includes('(cd package/translate && bash ./build)'),
 	'the packaging workflow must invoke Bash-only translation helpers with Bash'
 )
+assert.ok(
+	rootBuild.includes('python3 -m zipfile -c "$filename" ./*'),
+	'packaging must fall back to Python when the external zip command is unavailable'
+)
 
 for (const helper of ['package/translate/build', 'package/translate/merge']) {
 	const source = read(helper)

--- a/tests/docs_command_blocks.test.js
+++ b/tests/docs_command_blocks.test.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const path = require('path')
 
 const html = fs.readFileSync(path.join(__dirname, '../docs/index.html'), 'utf8')
+const contributing = fs.readFileSync(path.join(__dirname, '../CONTRIBUTING.md'), 'utf8')
 
 assert.ok(
 	html.includes('prism-tomorrow.min.css'),
@@ -27,6 +28,25 @@ for (const [, preAttrs, codeAttrs] of commandBlocks) {
 	assert.match(preAttrs, /class="[^"]*\bcode-block\b[^"]*\bcommand-line\b[^"]*"/, 'command blocks must use Prism command-line plugin')
 	assert.match(preAttrs, /data-prompt="\$"/, 'command blocks must show a shell prompt')
 	assert.match(codeAttrs, /class="[^"]*\blanguage-bash\b[^"]*"/, 'command blocks must declare bash syntax highlighting')
+}
+
+assert.ok(
+	html.includes('git clone -b master') && contributing.includes('git clone -b master'),
+	'website and contributor setup must target the active master branch'
+)
+assert.doesNotMatch(
+	html,
+	/sh \.\/(?:install|update)/,
+	'website commands must honor the Bash shebangs'
+)
+const contributingFences = contributing.match(/^```.*$/gm) || []
+assert.equal(contributingFences.length % 2, 0, 'contributor code fences must be balanced')
+for (let index = 0; index < contributingFences.length; index += 2) {
+	assert.equal(
+		contributingFences[index],
+		'```bash',
+		'contributor code fences must declare a language'
+	)
 }
 
 console.log('PASS docs_command_blocks')

--- a/tests/exec_util_lifecycle.test.js
+++ b/tests/exec_util_lifecycle.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+
+const source = fs.readFileSync(
+	path.join(__dirname, '../package/contents/ui/lib/ExecUtil.qml'),
+	'utf8'
+)
+
+function functionBody(startMarker, endMarker) {
+	const start = source.indexOf(startMarker)
+	const end = source.indexOf(endMarker, start)
+	assert.ok(start >= 0 && end > start, `could not find ${startMarker}`)
+	return source.slice(start, end)
+}
+
+function assertOrdered(body, markers, message) {
+	let previous = -1
+	for (const marker of markers) {
+		const index = body.indexOf(marker)
+		assert.ok(index > previous, `${message}: ${marker}`)
+		previous = index
+	}
+}
+
+const completion = functionBody('onNewData: function', '\n\tsignal exited')
+assertOrdered(completion, [
+	'var listener = listeners[cmd]',
+	'delete listeners[cmd]',
+	'disconnectSource(sourceName)',
+	'listener(cmd, exitCode, exitStatus, stdout, stderr)',
+	'exited(cmd, exitCode, exitStatus, stdout, stderr)',
+], 'completed sources must be cleaned up before restartable handlers run')
+
+const runCommand = functionBody('function runCommand', '\n\tfunction exec(')
+assertOrdered(runCommand, [
+	'delete listeners[cmd]',
+	'disconnectSource(cmd)',
+	"if (typeof callback === 'function')",
+	'listeners[cmd] = listener',
+	'\n\t\tconnectSource(cmd)',
+], 'every replacement run must clear stale state before reconnecting')
+
+assert.ok(
+	!runCommand.includes('exited.disconnect'),
+	'listener callbacks are not signal connections and must not be disconnected as signals'
+)
+
+console.log('PASS exec_util_lifecycle')

--- a/tests/ical_manager_lifecycle.test.js
+++ b/tests/ical_manager_lifecycle.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+
+function read(relativePath) {
+	return fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf8')
+}
+
+const eventModel = read('package/contents/ui/EventModel.qml')
+const manager = read('package/contents/ui/calendars/ICalManager.qml')
+
+assert.ok(
+	eventModel.includes('bindSignals(icalManager)'),
+	'EventModel must bind the iCalendar manager into the shared fetch lifecycle'
+)
+assert.ok(
+	manager.includes('icalManager.asyncRequests += 1')
+		&& !manager.includes('icalManager.asyncRequests += 0'),
+	'each iCalendar subprocess must be counted as an asynchronous request'
+)
+assert.ok(
+	manager.includes('} finally {\n\t\t\t\ticalManager.asyncRequestsDone += 1'),
+	'iCalendar requests must complete exactly once on success and failure'
+)
+assert.ok(
+	manager.includes('if (err) {')
+		&& manager.indexOf('if (err) {') < manager.indexOf('setCalendarData(calendarData.url, data)'),
+	'failed helper responses must not be dereferenced or stored as event data'
+)
+assert.ok(
+	manager.includes('calendarData.show !== false'),
+	'disabled iCalendar feeds must not be fetched or displayed'
+)
+assert.ok(
+	manager.includes('Array.isArray(parsed.items)'),
+	'the helper response must be validated before calendar parsing'
+)
+assert.ok(
+	manager.indexOf('callback(null, parsed)') > manager.indexOf('} catch (err) {'),
+	'consumer callbacks must run outside the JSON parse catch to avoid double completion'
+)
+assert.ok(
+	!manager.includes("logger.debug('ical.fetchEvents', calendarData.url)"),
+	'private published-calendar URLs must not be written to debug logs'
+)
+
+console.log('PASS ical_manager_lifecycle')

--- a/tests/icsjson_test.py
+++ b/tests/icsjson_test.py
@@ -62,6 +62,43 @@ class IcsJsonTests(unittest.TestCase):
 			icsjson.event_within(event, start, start + datetime.timedelta(seconds=1))
 		)
 
+	def test_all_day_event_without_end_defaults_to_one_day(self):
+		calendar = parse_calendar(
+			"BEGIN:VEVENT\r\n"
+			"UID:all-day-test\r\n"
+			"DTSTART;VALUE=DATE:20260703\r\n"
+			"SUMMARY:All-day test\r\n"
+			"END:VEVENT\r\n"
+		)
+		event = calendar.walk("vevent")[0]
+		payload = json.loads(icsjson.events_to_json([event]))
+
+		self.assertEqual(payload["items"][0]["start"], {"date": "2026-07-03"})
+		self.assertEqual(payload["items"][0]["end"], {"date": "2026-07-04"})
+
+	def test_duration_description_and_cancelled_status_are_respected(self):
+		calendar = parse_calendar(
+			"BEGIN:VEVENT\r\n"
+			"UID:duration-test\r\n"
+			"DTSTART:20260703T100000Z\r\n"
+			"DURATION:PT90M\r\n"
+			"DESCRIPTION:Useful details\r\n"
+			"SUMMARY:Duration test\r\n"
+			"END:VEVENT\r\n"
+			"BEGIN:VEVENT\r\n"
+			"UID:cancelled-test\r\n"
+			"DTSTART:20260703T120000Z\r\n"
+			"DTEND:20260703T130000Z\r\n"
+			"STATUS:CANCELLED\r\n"
+			"SUMMARY:Cancelled test\r\n"
+			"END:VEVENT\r\n"
+		)
+		payload = json.loads(icsjson.events_to_json(calendar.walk("vevent")))
+
+		self.assertEqual(len(payload["items"]), 1)
+		self.assertEqual(payload["items"][0]["end"], {"dateTime": "2026-07-03T11:30:00+00:00"})
+		self.assertEqual(payload["items"][0]["description"], "Useful details")
+
 	def test_query_delegates_expansion_to_recurring_ical_events(self):
 		calendar = parse_calendar(
 			"BEGIN:VEVENT\r\n"

--- a/tests/icsjson_test.py
+++ b/tests/icsjson_test.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import json
+import pathlib
+import unittest
+from unittest import mock
+
+from icalendar import Calendar
+
+
+SCRIPT_PATH = pathlib.Path(__file__).parents[1] / "package/contents/scripts/icsjson.py"
+SPEC = importlib.util.spec_from_file_location("eventcalendar_icsjson", SCRIPT_PATH)
+icsjson = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(icsjson)
+
+
+def parse_calendar(events: str) -> Calendar:
+	return Calendar.from_ical(
+		("BEGIN:VCALENDAR\r\nVERSION:2.0\r\n" + events + "END:VCALENDAR\r\n").encode()
+	)
+
+
+class IcsJsonTests(unittest.TestCase):
+	def test_timezone_aware_values_are_normalized_to_local_naive_time(self):
+		aware = datetime.datetime(2026, 7, 3, 0, 30, tzinfo=datetime.timezone.utc)
+		expected = aware.astimezone().replace(tzinfo=None)
+
+		self.assertEqual(icsjson.ensure_date_time(aware), expected)
+
+	def test_event_filter_uses_half_open_bounds(self):
+		calendar = parse_calendar(
+			"BEGIN:VEVENT\r\n"
+			"UID:boundary-test\r\n"
+			"DTSTART:20260703T100000Z\r\n"
+			"DTEND:20260703T110000Z\r\n"
+			"SUMMARY:Boundary test\r\n"
+			"END:VEVENT\r\n"
+		)
+		event = calendar.walk("vevent")[0]
+		start = icsjson.ensure_date_time(event["DTSTART"].dt)
+		end = icsjson.ensure_date_time(event["DTEND"].dt)
+
+		self.assertTrue(icsjson.event_within(event, start, end))
+		self.assertFalse(icsjson.event_within(event, end, end + datetime.timedelta(hours=1)))
+		self.assertFalse(icsjson.event_within(event, start - datetime.timedelta(hours=1), start))
+
+	def test_zero_duration_event_is_included_at_its_start(self):
+		calendar = parse_calendar(
+			"BEGIN:VEVENT\r\n"
+			"UID:instant-test\r\n"
+			"DTSTART:20260703T100000Z\r\n"
+			"SUMMARY:Instant test\r\n"
+			"END:VEVENT\r\n"
+		)
+		event = calendar.walk("vevent")[0]
+		start = icsjson.ensure_date_time(event["DTSTART"].dt)
+
+		self.assertTrue(
+			icsjson.event_within(event, start, start + datetime.timedelta(seconds=1))
+		)
+
+	def test_query_delegates_expansion_to_recurring_ical_events(self):
+		calendar = parse_calendar(
+			"BEGIN:VEVENT\r\n"
+			"UID:delegation-test\r\n"
+			"DTSTART:20260703T100000Z\r\n"
+			"DTEND:20260703T110000Z\r\n"
+			"SUMMARY:Delegation test\r\n"
+			"END:VEVENT\r\n"
+		)
+		event = calendar.walk("vevent")[0]
+		start = datetime.datetime(2026, 7, 1)
+		end = datetime.datetime(2026, 7, 5)
+		query = mock.Mock()
+		query.between.return_value = [event]
+		dependency = mock.Mock()
+		dependency.of.return_value = query
+		manager = icsjson.CalendarManager("unused")
+		manager.cal = calendar
+
+		with mock.patch.object(icsjson, "recurring_ical_events", dependency):
+			self.assertEqual(list(manager.query(start, end)), [event])
+
+		dependency.of.assert_called_once_with(calendar)
+		query.between.assert_called_once_with(start, end)
+
+	@unittest.skipUnless(
+		icsjson.recurring_ical_events is not None,
+		"recurring-ical-events is not installed",
+	)
+	def test_recurring_events_apply_exdates_and_overrides(self):
+		calendar = parse_calendar(
+			"BEGIN:VEVENT\r\n"
+			"UID:daily-test\r\n"
+			"DTSTART:20260701T100000Z\r\n"
+			"DTEND:20260701T110000Z\r\n"
+			"RRULE:FREQ=DAILY;COUNT=4\r\n"
+			"EXDATE:20260702T100000Z\r\n"
+			"SUMMARY:Daily test\r\n"
+			"END:VEVENT\r\n"
+			"BEGIN:VEVENT\r\n"
+			"UID:daily-test\r\n"
+			"RECURRENCE-ID:20260703T100000Z\r\n"
+			"DTSTART:20260703T120000Z\r\n"
+			"DTEND:20260703T130000Z\r\n"
+			"SUMMARY:Moved occurrence\r\n"
+			"END:VEVENT\r\n"
+		)
+		manager = icsjson.CalendarManager("unused")
+		manager.cal = calendar
+
+		events = list(manager.query(
+			datetime.datetime(2026, 7, 1),
+			datetime.datetime(2026, 7, 5),
+		))
+		payload = json.loads(icsjson.events_to_json(events))
+
+		self.assertEqual(len(events), 3)
+		self.assertEqual(
+			[item["summary"] for item in payload["items"]],
+			["Daily test", "Moved occurrence", "Daily test"],
+		)
+		self.assertEqual(len({item["id"] for item in payload["items"]}), 3)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/install_ical_dependencies.test.js
+++ b/tests/install_ical_dependencies.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+
+function read(relativePath) {
+	return fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf8')
+}
+
+const install = read('install')
+const update = read('update')
+const helper = read('package/contents/scripts/icsjson.py')
+const readme = read('ReadMe.md')
+
+for (const [name, source] of [['install', install], ['update', update]]) {
+	assert.ok(source.includes('"python3-pip"') && source.includes('"python-pip"'),
+		`${name} must provide pip on supported distro families`)
+	assert.ok(source.includes("'recurring-ical-events>=3.8,<4'"),
+		`${name} must install the recurrence dependency with a compatible version range`)
+	assert.ok(source.includes('install_requirements\ninstall_python_calendar_dependencies'),
+		`${name} must invoke the user-local recurrence dependency installer`)
+	assert.ok(source.includes('.local/share/plasma_org.kde.plasma.eventcalendar/python'),
+		`${name} must keep Python dependencies out of the system environment`)
+}
+
+assert.ok(
+	helper.includes('sys.path.insert(0, LOCAL_PYTHON_DIR)'),
+	'the iCalendar helper must load dependencies from the applet data directory'
+)
+assert.ok(
+	readme.includes('recurring-ical-events>=3.8,<4'),
+	'the recurrence dependency must be documented for non-script installs'
+)
+
+console.log('PASS install_ical_dependencies')

--- a/tests/install_path_safety.test.js
+++ b/tests/install_path_safety.test.js
@@ -5,8 +5,13 @@ const path = require('path')
 const source = fs.readFileSync(path.join(__dirname, '../install'), 'utf8')
 
 assert.ok(
-	source.includes('[[ ! "$packageNamespace" =~ ^[A-Za-z0-9._-]+$ ]]'),
+	source.includes('! "$packageNamespace" =~ ^[A-Za-z0-9._-]+$'),
 	'install must reject package namespaces that could escape the plasmoid directory'
+)
+assert.ok(
+	source.includes('|| "$packageNamespace" == "."') &&
+		source.includes('|| "$packageNamespace" == ".."'),
+	'install must reject dot path components before recursive replacement'
 )
 assert.ok(
 	source.includes('PACKAGE_INSTALL_DIR="${INSTALL_DIR:?}/${packageNamespace:?}"'),

--- a/tests/install_path_safety.test.js
+++ b/tests/install_path_safety.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+
+const source = fs.readFileSync(path.join(__dirname, '../install'), 'utf8')
+
+assert.ok(
+	source.includes('[[ ! "$packageNamespace" =~ ^[A-Za-z0-9._-]+$ ]]'),
+	'install must reject package namespaces that could escape the plasmoid directory'
+)
+assert.ok(
+	source.includes('PACKAGE_INSTALL_DIR="${INSTALL_DIR:?}/${packageNamespace:?}"'),
+	'install must require both path components before constructing the replacement target'
+)
+assert.ok(
+	source.includes('rm -rf -- "$PACKAGE_INSTALL_DIR"'),
+	'install must delete only the validated package destination'
+)
+
+console.log('PASS install_path_safety')

--- a/tests/translation_catalogs.test.js
+++ b/tests/translation_catalogs.test.js
@@ -1,0 +1,19 @@
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+
+const catalogDirectory = path.join(__dirname, '../package/translate')
+const catalogs = fs.readdirSync(catalogDirectory).filter(file => file.endsWith('.po'))
+
+assert.ok(catalogs.length > 0, 'translation catalogs must be present')
+
+for (const catalog of catalogs) {
+	const source = fs.readFileSync(path.join(catalogDirectory, catalog), 'utf8')
+	assert.doesNotMatch(
+		source,
+		/nplurals=INTEGER|plural=EXPRESSION/,
+		`${catalog} must declare a valid locale-specific plural rule`
+	)
+}
+
+console.log(`PASS translation_catalogs (${catalogs.length} catalogs)`)

--- a/update
+++ b/update
@@ -28,6 +28,7 @@ DISTRO=""
 DISTRO_LIKE=""
 DISTRO_FAMILY=""
 PACKAGES_UPDATED=false
+PYTHON_PACKAGE_DIR="$HOME/.local/share/plasma_org.kde.plasma.eventcalendar/python"
 
 detect_plasma_major() {
     local version_line=""
@@ -129,6 +130,40 @@ install_packages_optional() {
     done
 }
 
+install_python_calendar_dependencies() {
+    local python_path="$PYTHON_PACKAGE_DIR"
+    local import_path="$python_path"
+    if [ -n "${PYTHONPATH:-}" ]; then
+        import_path="$python_path:$PYTHONPATH"
+    fi
+
+    if PYTHONPATH="$import_path" python3 -c 'import icalendar, recurring_ical_events' >/dev/null 2>&1; then
+        return 0
+    fi
+    if ! python3 -m pip --version >/dev/null 2>&1; then
+        log "WARNING: python3-pip is unavailable; recurring iCalendar events will not be expanded."
+        return 0
+    fi
+    if ! mkdir -p "$python_path"; then
+        log "WARNING: Could not create the local Python dependency directory."
+        return 0
+    fi
+
+    log "Installing recurring iCalendar support in the applet data directory..."
+    if ! python3 -m pip install \
+        --disable-pip-version-check \
+        --no-warn-script-location \
+        --upgrade \
+        --target "$python_path" \
+        'recurring-ical-events>=3.8,<4'; then
+        log "WARNING: recurring-ical-events failed to install; recurring events may be missing."
+        return 0
+    fi
+    if ! PYTHONPATH="$import_path" python3 -c 'import icalendar, recurring_ical_events' >/dev/null 2>&1; then
+        log "WARNING: Installed iCalendar dependencies could not be imported."
+    fi
+}
+
 install_requirements() {
     detect_distro
 
@@ -159,6 +194,7 @@ install_requirements() {
             )
             optional_packages=(
                 "python3-icalendar"
+                "python3-pip"
                 "akonadi-server"
                 "kdepim-addons"
                 "konsolekalendar"
@@ -185,6 +221,7 @@ install_requirements() {
             )
             optional_packages=(
                 "python-icalendar"
+                "python-pip"
                 "akonadi"
                 "kdepim-addons"
                 "kdepim-runtime"
@@ -211,6 +248,7 @@ install_requirements() {
             )
             optional_packages=(
                 "python3-icalendar"
+                "python3-pip"
                 "akonadi-server"
                 "kdepim-addons"
                 "kdepim-runtime"
@@ -253,6 +291,7 @@ if [ -z "$plasma_major" ]; then
 fi
 
 install_requirements
+install_python_calendar_dependencies
 
 if ! git rev-parse --git-dir > /dev/null 2>&1; then
     log "ERROR: Not in a git repository"


### PR DESCRIPTION
## Problem

Configured ICS/iCalendar URLs (e.g. Outlook published calendars) never showed any events. Three independent bugs stacked on top of each other:

### 1. The ICS manager was never bound
`EventModel.qml` instantiates `icalManager`, but `bindSignals(icalManager)` is never called, so it's never added to `calendarManagerList`. `fetchAllCalendars` only iterates that list → **configured ICS calendars are never fetched at all**. Debug log only ever shows `onCalendarFetched plasma_Holidays`.

**Fix:** call `bindSignals(icalManager)` in `Component.onCompleted`.

### 2. icsjson.py crashed on mixed tz-aware/naive datetimes
Outlook feeds mix tz-aware timed events with naive all-day dates. `event_within()` compared them against the naive query bounds:

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

**Fix:** normalize tz-aware datetimes to local naive in `ensure_date_time()`.

### 3. Recurring events only appeared on their series start date
Without RRULE expansion, `event_within()` matches a recurring series only via its master `DTSTART`/`DTEND`. A weekly standup whose series started last year is invisible for the current month — in a real Outlook calendar with 100+ RRULE series, almost all meetings were silently missing (a day showing 1 event in the widget vs 10 in Outlook web).

**Fix:** expand occurrences via [recurring-ical-events](https://pypi.org/project/recurring-ical-events/) (handles RRULE, EXDATE, RECURRENCE-ID overrides) when importable, with graceful fallback to the previous behavior when the module is absent — no hard new dependency.

## Also: ExecUtil.runCommand silently broke after suspend/resume

If a spawned process never called back (e.g. hung across suspend, DNS down on wake), its listener stayed in the `listeners` map. The next run of the same command hit `exited.disconnect(listeners[cmd])` — but map entries are never connected to the `exited` signal, so this **throws and aborts `runCommand` before `connectSource`**. Every subsequent run of that command was silently dropped until plasmashell restarted (observed: ICS refreshes stopped forever after a laptop resume; `fetchEvents` logged, callback never fired).

**Fix:** drop the stale map entry instead of disconnecting, and `disconnectSource(cmd)` before `connectSource(cmd)` so an identical command re-executes even if the engine still holds a stuck source.

## Testing

- Outlook 365 published calendar (~4 MB, 1189 VEVENTs, 106 RRULE series) on Plasma 6.x / Arch:
  - Before: zero ICS events rendered; after fix 1+2: one-off events only; after fix 3: day view matches Outlook web (only group-calendar events absent, which the published feed doesn't contain).
  - `python3 icsjson.py --url <url> query 2026-7-20 2026-7-21` returns all 10 expected occurrences incl. weekly meetings.
- ExecUtil: refresh cycles verified working across repeated fetches and after the previously-stuck state (fetch → `onCalendarFetched <url>` on every cycle, not just the first after restart).
- `python3 -m py_compile` passes; fallback path (no `recurring_ical_events`) exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recurring iCalendar events are now expanded and shown within the active time range when recurrence support is available.

- **Bug Fixes**
  - Improved date/time handling for time zones, including correct boundary behavior for event inclusion.
  - Better iCal event parsing: all-day defaults, DURATION-based end times, and canceled events are skipped; event status/description are included when available.
  - Improved command lifecycle cleanup to prevent stale executions after interruptions like suspend/resume.

- **Chores**
  - Updated build/install and added automated coverage for iCal dependency installation and event/query behavior.
  - Refreshed contributor/testing and maintenance documentation to match current branch guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->